### PR TITLE
Add MCP server for read-only DNS record access

### DIFF
--- a/backend/go.mod
+++ b/backend/go.mod
@@ -5,6 +5,14 @@ go 1.24
 require go.etcd.io/etcd/client/v3 v3.6.1
 
 require (
+	github.com/google/jsonschema-go v0.4.2 // indirect
+	github.com/google/uuid v1.6.0 // indirect
+	github.com/mark3labs/mcp-go v0.54.0
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
+	github.com/yosida95/uritemplate/v3 v3.0.2 // indirect
+)
+
+require (
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/coreos/go-systemd/v22 v22.5.0 // indirect
 	github.com/fsnotify/fsnotify v1.8.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -22,6 +22,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/jsonschema-go v0.4.2 h1:tmrUohrwoLZZS/P3x7ex0WAVknEkBZM46iALbcqoRA8=
+github.com/google/jsonschema-go v0.4.2/go.mod h1:r5quNTdLOYEz95Ru18zA0ydNbBuYoo9tgaYcxEYhJVE=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.26.3 h1:5ZPtiqj0JL5oKWmcsq4VMaAW5ukBEgSGXEN89zeH1Jo=
@@ -34,6 +36,8 @@ github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/mark3labs/mcp-go v0.54.0 h1:PZhQvd+5xrT43cUoiaKn/hDcvLUhcLc1twSEKYPTcTA=
+github.com/mark3labs/mcp-go v0.54.0/go.mod h1:+8WclSK1ZUweCP3hvktSji8n8ABG/95QaEkeVE/Uwas=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -52,6 +56,8 @@ github.com/rs/zerolog v1.34.0/go.mod h1:bJsvje4Z08ROH4Nhs5iH600c3IkWhwp44iRc54W6
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.7.0 h1:5MqpDsTGNDhY8sGp0Aowyf0qKsPrhewaLSsFaodPcyo=
 github.com/sagikazarmark/locafero v0.7.0/go.mod h1:2za3Cg5rMaTMoG/2Ulr9AwtFaIppKXTRYnozin4aB5k=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 h1:KRzFb2m7YtdldCEkzs6KqmJw4nqEVZGK7IN2kJkjTuQ=
+github.com/santhosh-tekuri/jsonschema/v6 v6.0.2/go.mod h1:JXeL+ps8p7/KNMjDQk3TCwPpBy0wYklyWTfbkIzdIFU=
 github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9ySo=
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/spf13/afero v1.12.0 h1:UcOPyRBYczmFn6yvphxkn9ZEOY65cpwGKb5mL36mrqs=
@@ -68,6 +74,8 @@ github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOf
 github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8=
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
+github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
+github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 go.etcd.io/etcd/api/v3 v3.6.1 h1:yJ9WlDih9HT457QPuHt/TH/XtsdN2tubyxyQHSHPsEo=

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/auto-dns/auto-dns-webui/internal/api"
 	"github.com/auto-dns/auto-dns-webui/internal/config"
+	mcphandler "github.com/auto-dns/auto-dns-webui/internal/mcp"
 	"github.com/auto-dns/auto-dns-webui/internal/registry"
 	"github.com/auto-dns/auto-dns-webui/internal/server"
 	"github.com/rs/zerolog"
@@ -15,8 +16,9 @@ import (
 )
 
 type App struct {
-	Logger zerolog.Logger
-	Server httpServer
+	Logger    zerolog.Logger
+	Server    httpServer
+	MCPServer *http.Server
 }
 
 func NewRegistry(cfg *config.Config, logger zerolog.Logger) (registry.Registry, error) {
@@ -57,14 +59,45 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 
 	srv := NewServer(&cfg.Server, handler, logger)
 
+	var mcpHTTP *http.Server
+	if cfg.MCP.Enabled {
+		mcpHandler := mcphandler.NewHandler(mcphandler.Deps{
+			Registry: reg,
+			Logger:   logger,
+		})
+		mcpHTTP = &http.Server{
+			Addr:              fmt.Sprintf(":%d", cfg.MCP.Port),
+			Handler:           mcpHandler,
+			ReadHeaderTimeout: 10 * time.Second,
+			WriteTimeout:      0,
+			IdleTimeout:       120 * time.Second,
+		}
+		logger.Info().Int("port", cfg.MCP.Port).Msg("MCP server configured")
+	}
+
 	return &App{
-		Logger: logger,
-		Server: srv,
+		Logger:    logger,
+		Server:    srv,
+		MCPServer: mcpHTTP,
 	}, nil
 }
 
 // Run starts the application by running the sync engine.
 func (a *App) Run(ctx context.Context) error {
 	a.Logger.Info().Msg("Application starting")
+
+	if a.MCPServer != nil {
+		go func() {
+			a.Logger.Info().Str("addr", a.MCPServer.Addr).Msg("MCP server starting")
+			go a.MCPServer.ListenAndServe() //nolint:errcheck
+			<-ctx.Done()
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := a.MCPServer.Shutdown(shutdownCtx); err != nil {
+				a.Logger.Error().Err(err).Msg("MCP server shutdown error")
+			}
+		}()
+	}
+
 	return a.Server.Start(ctx)
 }

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -13,6 +13,7 @@ type Config struct {
 	App    AppConfig     `mapstructure:"app"`
 	Etcd   EtcdConfig    `mapstructure:"etcd"`
 	Log    LoggingConfig `mapstructure:"log"`
+	MCP    MCPConfig     `mapstructure:"mcp"`
 	Server ServerConfig  `mapstructure:"server"`
 }
 
@@ -42,6 +43,11 @@ type ProxyConfig struct {
 	Enable   bool   `mapstructure:"enable"`
 	Hostname string `mapstructure:"hostname"`
 	Port     int    `mapstructure:"port"`
+}
+
+type MCPConfig struct {
+	Enabled bool `mapstructure:"enabled"`
+	Port    int  `mapstructure:"port"`
 }
 
 func Load() (*Config, error) {
@@ -93,6 +99,8 @@ func initConfig() error {
 	viper.SetDefault("etcd.lock_timeout", 2.0)
 	viper.SetDefault("etcd.lock_retry_interval", 0.1)
 	viper.SetDefault("log.level", "INFO")
+	viper.SetDefault("mcp.enabled", false)
+	viper.SetDefault("mcp.port", 0)
 	viper.SetDefault("server.port", 8080)
 	viper.SetDefault("server.proxy.enable", false)
 	viper.SetDefault("server.proxy.hostname", "localhost")
@@ -145,6 +153,9 @@ func (c *Config) validate() error {
 	}
 	if c.Server.Port <= 0 || c.Server.Port > 65535 {
 		return fmt.Errorf("server.port must be a valid TCP port")
+	}
+	if c.MCP.Enabled && (c.MCP.Port <= 0 || c.MCP.Port > 65535) {
+		return fmt.Errorf("mcp.port must be a valid TCP port when mcp.enabled is true")
 	}
 	return nil
 }

--- a/backend/internal/mcp/handler.go
+++ b/backend/internal/mcp/handler.go
@@ -1,0 +1,25 @@
+package mcphandler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/rs/zerolog"
+)
+
+type dnsRegistry interface {
+	List(ctx context.Context) ([]*dns.Record, error)
+}
+
+type Deps struct {
+	Registry dnsRegistry
+	Logger   zerolog.Logger
+}
+
+func NewHandler(d Deps) http.Handler {
+	s := server.NewMCPServer("auto-dns-webui", "1.0.0")
+	registerTools(s, d)
+	return server.NewStreamableHTTPServer(s, server.WithStateLess(true))
+}

--- a/backend/internal/mcp/tools.go
+++ b/backend/internal/mcp/tools.go
@@ -1,0 +1,151 @@
+package mcphandler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
+)
+
+// --- Output types ---
+
+type dnsRecordOut struct {
+	Name          string `json:"name"`
+	Type          string `json:"type"`
+	Value         string `json:"value"`
+	Hostname      string `json:"hostname"`
+	ContainerName string `json:"containerName"`
+	ContainerID   string `json:"containerId"`
+	Created       string `json:"created"`
+	Force         bool   `json:"force"`
+}
+
+type listRecordsOut struct {
+	Total   int            `json:"total"`
+	Records []dnsRecordOut `json:"records"`
+}
+
+// --- Helpers ---
+
+func jsonText(v any) *mcp.CallToolResult {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return mcp.NewToolResultError(fmt.Sprintf("failed to marshal result: %v", err))
+	}
+	return mcp.NewToolResultText(string(data))
+}
+
+func toRecordOut(r *dns.Record) dnsRecordOut {
+	return dnsRecordOut{
+		Name:          r.Dns.Name,
+		Type:          r.Dns.Type,
+		Value:         r.Dns.Value,
+		Hostname:      r.Meta.Hostname,
+		ContainerName: r.Meta.ContainerName,
+		ContainerID:   r.Meta.ContainerID,
+		Created:       r.Meta.Created.UTC().Format(time.RFC3339),
+		Force:         r.Meta.Force,
+	}
+}
+
+// --- Tool registration ---
+
+func registerTools(s *server.MCPServer, d Deps) {
+	s.AddTool(mcp.NewTool("list_dns_records",
+		mcp.WithDescription("List all DNS records registered in etcd. Optionally filter by name substring, record type (A/AAAA/CNAME), or the hostname of the docker-coredns-sync node that registered them."),
+		mcp.WithString("name", mcp.Description("Substring to match against the DNS name (case-insensitive).")),
+		mcp.WithString("type", mcp.Description(`Record type filter: "A", "AAAA", or "CNAME".`)),
+		mcp.WithString("hostname", mcp.Description("Exact hostname of the docker-coredns-sync node that registered the record.")),
+	), makeListDNSRecords(d))
+
+	s.AddTool(mcp.NewTool("get_dns_record",
+		mcp.WithDescription("Look up a DNS record by its exact fully-qualified domain name (FQDN)."),
+		mcp.WithString("name", mcp.Required(), mcp.Description("Exact FQDN to look up (e.g. myservice.carroll.live).")),
+	), makeGetDNSRecord(d))
+
+	s.AddTool(mcp.NewTool("get_records_by_host",
+		mcp.WithDescription("Get all DNS records registered by a specific docker-coredns-sync node, identified by hostname."),
+		mcp.WithString("hostname", mcp.Required(), mcp.Description("Exact hostname of the docker-coredns-sync node (e.g. mozart).")),
+	), makeGetRecordsByHost(d))
+}
+
+// --- Tool handlers ---
+
+func makeListDNSRecords(d Deps) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		records, err := d.Registry.List(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("error listing DNS records: %v", err)), nil
+		}
+
+		nameFilter := strings.ToLower(req.GetString("name", ""))
+		typeFilter := strings.ToUpper(req.GetString("type", ""))
+		hostFilter := req.GetString("hostname", "")
+
+		out := listRecordsOut{Records: []dnsRecordOut{}}
+		for _, r := range records {
+			if nameFilter != "" && !strings.Contains(strings.ToLower(r.Dns.Name), nameFilter) {
+				continue
+			}
+			if typeFilter != "" && r.Dns.Type != typeFilter {
+				continue
+			}
+			if hostFilter != "" && r.Meta.Hostname != hostFilter {
+				continue
+			}
+			out.Records = append(out.Records, toRecordOut(r))
+		}
+		out.Total = len(out.Records)
+		return jsonText(out), nil
+	}
+}
+
+func makeGetDNSRecord(d Deps) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		name := req.GetString("name", "")
+		if name == "" {
+			return mcp.NewToolResultError("name is required"), nil
+		}
+
+		records, err := d.Registry.List(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("error fetching DNS records: %v", err)), nil
+		}
+
+		target := strings.TrimSuffix(strings.ToLower(name), ".")
+		for _, r := range records {
+			if strings.TrimSuffix(strings.ToLower(r.Dns.Name), ".") == target {
+				return jsonText(toRecordOut(r)), nil
+			}
+		}
+		return mcp.NewToolResultText(fmt.Sprintf(`{"found":false,"name":%q}`, name)), nil
+	}
+}
+
+func makeGetRecordsByHost(d Deps) server.ToolHandlerFunc {
+	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		hostname := req.GetString("hostname", "")
+		if hostname == "" {
+			return mcp.NewToolResultError("hostname is required"), nil
+		}
+
+		records, err := d.Registry.List(ctx)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("error fetching DNS records: %v", err)), nil
+		}
+
+		out := listRecordsOut{Records: []dnsRecordOut{}}
+		for _, r := range records {
+			if r.Meta.Hostname == hostname {
+				out.Records = append(out.Records, toRecordOut(r))
+			}
+		}
+		out.Total = len(out.Records)
+		return jsonText(out), nil
+	}
+}

--- a/backend/internal/mcp/tools.go
+++ b/backend/internal/mcp/tools.go
@@ -64,7 +64,7 @@ func registerTools(s *server.MCPServer, d Deps) {
 	), makeListDNSRecords(d))
 
 	s.AddTool(mcp.NewTool("get_dns_record",
-		mcp.WithDescription("Look up a DNS record by its exact fully-qualified domain name (FQDN)."),
+		mcp.WithDescription("Look up all DNS records for an exact fully-qualified domain name (FQDN). Returns a list — the same FQDN may have multiple records (e.g. two A records from different containers)."),
 		mcp.WithString("name", mcp.Required(), mcp.Description("Exact FQDN to look up (e.g. myservice.carroll.live).")),
 	), makeGetDNSRecord(d))
 
@@ -108,9 +108,6 @@ func makeListDNSRecords(d Deps) server.ToolHandlerFunc {
 func makeGetDNSRecord(d Deps) server.ToolHandlerFunc {
 	return func(ctx context.Context, req mcp.CallToolRequest) (*mcp.CallToolResult, error) {
 		name := req.GetString("name", "")
-		if name == "" {
-			return mcp.NewToolResultError("name is required"), nil
-		}
 
 		records, err := d.Registry.List(ctx)
 		if err != nil {
@@ -118,12 +115,14 @@ func makeGetDNSRecord(d Deps) server.ToolHandlerFunc {
 		}
 
 		target := strings.TrimSuffix(strings.ToLower(name), ".")
+		out := listRecordsOut{Records: []dnsRecordOut{}}
 		for _, r := range records {
 			if strings.TrimSuffix(strings.ToLower(r.Dns.Name), ".") == target {
-				return jsonText(toRecordOut(r)), nil
+				out.Records = append(out.Records, toRecordOut(r))
 			}
 		}
-		return mcp.NewToolResultText(fmt.Sprintf(`{"found":false,"name":%q}`, name)), nil
+		out.Total = len(out.Records)
+		return jsonText(out), nil
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `internal/mcp/` package with a streamable HTTP MCP server built on `mcp-go v0.54.0`
- Exposes three read-only tools: `list_dns_records` (with optional name/type/hostname filters), `get_dns_record` (exact FQDN lookup), and `get_records_by_host` (all records from a given docker-coredns-sync node)
- MCP server runs as a separate `*http.Server` alongside the main server; enabled via `AUTO_DNS_WEBUI_MCP_ENABLED=true` and `AUTO_DNS_WEBUI_MCP_PORT=<port>`
- All filtering is in-memory after `registry.List()` — no etcd query changes needed
- Follows the same pattern as the pihole-cluster-admin MCP server (Phase 3)

## Test plan

- [ ] CI Docker build passes (Go 1.24 in Dockerfile)
- [ ] Start with `AUTO_DNS_WEBUI_MCP_ENABLED=true AUTO_DNS_WEBUI_MCP_PORT=8093`; verify `tools/list` returns all three tools
- [ ] Call `list_dns_records` with no filters; confirm all etcd records are returned
- [ ] Call `list_dns_records` with `type=A`, `hostname=mozart`; confirm filtering works
- [ ] Call `get_dns_record` with a known FQDN; confirm single record returned
- [ ] Call `get_dns_record` with unknown FQDN; confirm `{"found":false,...}` response
- [ ] Call `get_records_by_host` with a known hostname; confirm correct subset returned
- [ ] Wire into claude.ai as remote MCP server; verify tools appear and return live data

🤖 Generated with [Claude Code](https://claude.com/claude-code)