### PR TITLE
chore: upgrade Go to 1.26.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY frontend/ .
 RUN npm install && npm run build
 
 # ===== Stage 2: Build Go Backend =====
-FROM golang:1.24 AS backend-builder
+FROM golang:1.26.3 AS backend-builder
 WORKDIR /backend
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download
@@ -16,7 +16,7 @@ COPY --from=frontend-builder /frontend/dist ./internal/frontend/dist
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o auto-dns-webui ./cmd/auto-dns-webui
 
 # ===== Stage 3: Dev Container =====
-FROM mcr.microsoft.com/devcontainers/go:1.24 AS dev
+FROM mcr.microsoft.com/devcontainers/go:1.26 AS dev
 ENV ETCDCTL_ENDPOINTS="http://etcd:2379"
 ENV ETCDCTL_API=3
 RUN apt-get update && apt-get install -y \

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-dns/auto-dns-webui
 
-go 1.24
+go 1.26.3
 
 require go.etcd.io/etcd/client/v3 v3.6.1
 


### PR DESCRIPTION
## Summary
- Update `go` directive in `go.mod` from 1.24 to 1.26.3
- Update backend-builder Dockerfile stage from `golang:1.24` to `golang:1.26.3`
- Update dev container from `devcontainers/go:1.24` to `devcontainers/go:1.26`

## Test plan
- [ ] CI builds Docker image successfully on the new base

🤖 Generated with [Claude Code](https://claude.com/claude-code)