### PR TITLE
fix: correct YAML indentation in Create GitHub release step

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -85,23 +85,17 @@ jobs:
           version="${{ steps.version.outputs.version }}"
           prerelease="${{ steps.version.outputs.prerelease }}"
 
-          # Extract the matching section from CHANGELOG.md
-          body=$(awk "/^## \[$version\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md | sed '/^$/N;/^\n$/d')
-
-          # Append Docker image reference
-          body="${body}
-
-## Docker image
-
-\`\`\`
-docker pull ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${version}
-\`\`\`
-"
+          notes_file=$(mktemp)
+          awk "/^## \[$version\]/{found=1; next} found && /^## \[/{exit} found{print}" CHANGELOG.md \
+            | sed '/^$/N;/^\n$/d' > "$notes_file"
+          printf '\n## Docker image\n\n```\ndocker pull %s/%s:%s\n```\n' \
+            "${{ env.REGISTRY }}" "${{ env.IMAGE_NAME }}" "${version}" >> "$notes_file"
 
           prerelease_flag=""
           [ -n "$prerelease" ] && prerelease_flag="--prerelease"
 
           gh release create "v${version}" \
             --title "v${version}" \
-            --notes "$body" \
+            --notes-file "$notes_file" \
             $prerelease_flag
+          rm -f "$notes_file"


### PR DESCRIPTION
## Summary

- Fixes a YAML literal block scalar indentation bug in the "Create GitHub release" CI step introduced in the chore/changelog PR
- The `## Docker image` section and backtick fences were written at column 0 inside a `run: |` block whose content was established at 10-space indentation — this terminates the block early, breaking YAML parsing on every push
- Rewrote the step to write release notes to a temp file via `printf` so all shell lines stay within the required indentation

## Test plan

- [ ] Push to main no longer triggers "workflow file issue" errors
- [ ] Next tag push produces a Docker image and GitHub release with Docker pull command in the notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)