### PR TITLE
fix: use full image reference as imagetools create source

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -69,7 +69,7 @@ jobs:
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.major }} \
             --tag ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:latest \
-            ${{ steps.push-full.outputs.digest }}
+            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}
 
       - name: Generate artifact attestation
         uses: actions/attest-build-provenance@v2


### PR DESCRIPTION
## Summary

- `docker buildx imagetools create` requires a full image reference (e.g. `registry/image:tag`) as the source, not a bare digest (`sha256:...`)
- The previous code passed `${{ steps.push-full.outputs.digest }}` which expands to just `sha256:<hash>` — this would cause the step to fail for stable releases
- Fixed to use `${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.version.outputs.version }}` (the versioned tag pushed in the preceding step)

## Context

The "Push major/minor/latest tags for stable releases only" step was introduced in a previous PR. The YAML syntax error on line 96 (0-indented markdown backticks inside a `run: |` block) was already fixed in the prior commit; this PR addresses the remaining runtime bug.

## Test plan

- [ ] Push a stable tag (e.g. `v1.0.1`) and verify the "Push major/minor/latest tags" step completes without error
- [ ] Confirm `:latest`, `:1`, and `:1.0` tags are updated in GHCR

🤖 Generated with [Claude Code](https://claude.com/claude-code)