### PR TITLE
test: add backend unit tests (config, registry, API, MCP tools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend npm scripts (`lint`, `lint:fix`, `typecheck`, `format`, `format:check`), an ESLint flat config (`eslint.config.js`) using `typescript-eslint` + react-hooks, and Prettier config (`.prettierrc.json` / `.prettierignore`).
 - CI workflow (`.github/workflows/ci.yaml`) running backend (build, vet, golangci-lint, race tests) and frontend (lint, typecheck, build) jobs on pull requests and pushes to `main`/`v*` branches.
 - Dependency and vulnerability automation: `.github/dependabot.yml` (gomod, npm, github-actions) and `.github/workflows/security.yaml` running `govulncheck` (backend) and `npm audit` (frontend) on a schedule and on dependency changes.
+- Backend unit tests for config validation, the etcd registry (`parseEtcdValue`, `List`, `Remove`) via a mocked etcd client, the `/api/records` handler, and the MCP tools (`list_dns_records`, `get_dns_record`, `get_records_by_host`).
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// mockRegistry implements registry.Registry for handler tests.
+type mockRegistry struct {
+	records []*dns.Record
+	err     error
+}
+
+func (m *mockRegistry) List(ctx context.Context) ([]*dns.Record, error) { return m.records, m.err }
+func (m *mockRegistry) Remove(ctx context.Context, record *dns.Record) error { return nil }
+func (m *mockRegistry) LockTransaction(ctx context.Context, key []string, fn func() error) error {
+	return fn()
+}
+func (m *mockRegistry) Close() error { return nil }
+
+func TestRecords_Success(t *testing.T) {
+	reg := &mockRegistry{records: []*dns.Record{
+		{
+			Dns:  dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"},
+			Meta: dns.RecordMetadata{Hostname: "h1", Created: time.Now()},
+		},
+	}}
+	h := NewHandler(reg, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/records", nil)
+	rec := httptest.NewRecorder()
+	h.Records(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got []*dns.Record
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(got) != 1 || got[0].Dns.Name != "app.example.com" {
+		t.Errorf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestRecords_RegistryError(t *testing.T) {
+	h := NewHandler(&mockRegistry{err: errors.New("etcd down")}, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/records", nil)
+	rec := httptest.NewRecorder()
+	h.Records(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import "testing"
+
+// validConfig returns a Config that passes validate(); tests mutate one field
+// at a time to exercise each validation branch.
+func validConfig() Config {
+	return Config{
+		App:  AppConfig{Hostname: "dns1"},
+		Etcd: EtcdConfig{Host: "localhost", Port: 2379, PathPrefix: "/skydns", LockTTL: 5, LockTimeout: 2, LockRetryInterval: 0.1},
+		Log:  LoggingConfig{Level: "INFO"},
+		MCP:  MCPConfig{Enabled: false, Port: 0},
+		Server: ServerConfig{
+			Port:  8080,
+			Proxy: ProxyConfig{Enable: false, Hostname: "localhost", Port: 5173},
+		},
+	}
+}
+
+func TestValidate_Valid(t *testing.T) {
+	c := validConfig()
+	if err := c.validate(); err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestValidate_LogLevelCaseInsensitive(t *testing.T) {
+	c := validConfig()
+	c.Log.Level = "debug"
+	if err := c.validate(); err != nil {
+		t.Fatalf("lowercase log level should be accepted, got: %v", err)
+	}
+}
+
+func TestValidate_MCPPortRequiredWhenEnabled(t *testing.T) {
+	c := validConfig()
+	c.MCP.Enabled = true
+	c.MCP.Port = 0
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when mcp.enabled but mcp.port is invalid")
+	}
+
+	c.MCP.Port = 8092
+	if err := c.validate(); err != nil {
+		t.Fatalf("expected valid config with mcp enabled + port set, got: %v", err)
+	}
+}
+
+func TestValidate_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"empty app hostname", func(c *Config) { c.App.Hostname = "" }},
+		{"empty etcd host", func(c *Config) { c.Etcd.Host = "" }},
+		{"etcd port zero", func(c *Config) { c.Etcd.Port = 0 }},
+		{"etcd port too high", func(c *Config) { c.Etcd.Port = 70000 }},
+		{"empty path prefix", func(c *Config) { c.Etcd.PathPrefix = "" }},
+		{"lock ttl zero", func(c *Config) { c.Etcd.LockTTL = 0 }},
+		{"lock timeout zero", func(c *Config) { c.Etcd.LockTimeout = 0 }},
+		{"lock retry interval zero", func(c *Config) { c.Etcd.LockRetryInterval = 0 }},
+		{"invalid log level", func(c *Config) { c.Log.Level = "VERBOSE" }},
+		{"empty proxy hostname", func(c *Config) { c.Server.Proxy.Hostname = "" }},
+		{"proxy port zero", func(c *Config) { c.Server.Proxy.Port = 0 }},
+		{"server port too high", func(c *Config) { c.Server.Port = 99999 }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			tt.mutate(&c)
+			if err := c.validate(); err == nil {
+				t.Fatalf("%s: expected validation error, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/backend/internal/mcp/tools_test.go
+++ b/backend/internal/mcp/tools_test.go
@@ -1,0 +1,136 @@
+package mcphandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+type mockDNSRegistry struct {
+	records []*dns.Record
+	err     error
+}
+
+func (m *mockDNSRegistry) List(ctx context.Context) ([]*dns.Record, error) {
+	return m.records, m.err
+}
+
+func sampleRecords() []*dns.Record {
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	return []*dns.Record{
+		{Dns: dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"}, Meta: dns.RecordMetadata{Hostname: "alpha", Created: created}},
+		{Dns: dns.DnsRecord{Name: "db.example.com", Type: "AAAA", Value: "fd00::1"}, Meta: dns.RecordMetadata{Hostname: "beta", Created: created}},
+		{Dns: dns.DnsRecord{Name: "www.example.com", Type: "CNAME", Value: "app.example.com"}, Meta: dns.RecordMetadata{Hostname: "alpha", Created: created}},
+	}
+}
+
+func newReq(args map[string]any) mcp.CallToolRequest {
+	var req mcp.CallToolRequest
+	req.Params.Arguments = args
+	return req
+}
+
+// decode parses the JSON text payload of a successful tool result.
+func decode(t *testing.T, res *mcp.CallToolResult) listRecordsOut {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("tool returned an error result: %v", res.Content)
+	}
+	tc, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] is not TextContent: %T", res.Content[0])
+	}
+	var out listRecordsOut
+	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+		t.Fatalf("result text is not valid JSON: %v", err)
+	}
+	return out
+}
+
+func TestListDNSRecords_Filters(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeListDNSRecords(d)
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want int
+	}{
+		{"no filter returns all", map[string]any{}, 3},
+		{"type filter A", map[string]any{"type": "a"}, 1},
+		{"name substring", map[string]any{"name": "EXAMPLE"}, 3},
+		{"name substring narrow", map[string]any{"name": "db"}, 1},
+		{"hostname filter", map[string]any{"hostname": "alpha"}, 2},
+		{"combined type+hostname", map[string]any{"type": "CNAME", "hostname": "alpha"}, 1},
+		{"no match", map[string]any{"hostname": "ghost"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := handler(context.Background(), newReq(tt.args))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			out := decode(t, res)
+			if out.Total != tt.want || len(out.Records) != tt.want {
+				t.Errorf("total = %d (records %d), want %d", out.Total, len(out.Records), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDNSRecord_NormalizesTrailingDot(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeGetDNSRecord(d)
+
+	res, err := handler(context.Background(), newReq(map[string]any{"name": "APP.example.com."}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	out := decode(t, res)
+	if out.Total != 1 || out.Records[0].Name != "app.example.com" {
+		t.Errorf("expected exactly app.example.com, got %+v", out.Records)
+	}
+}
+
+func TestGetRecordsByHost(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeGetRecordsByHost(d)
+
+	t.Run("returns host subset", func(t *testing.T) {
+		res, err := handler(context.Background(), newReq(map[string]any{"hostname": "alpha"}))
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if out := decode(t, res); out.Total != 2 {
+			t.Errorf("total = %d, want 2", out.Total)
+		}
+	})
+
+	t.Run("missing hostname is an error", func(t *testing.T) {
+		res, err := handler(context.Background(), newReq(map[string]any{}))
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !res.IsError {
+			t.Error("expected IsError result when hostname is empty")
+		}
+	})
+}
+
+func TestListDNSRecords_RegistryError(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{err: errors.New("etcd down")}, Logger: zerolog.Nop()}
+	res, err := makeListDNSRecords(d)(context.Background(), newReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError result when registry.List fails")
+	}
+}

--- a/backend/internal/registry/etcd_registry_test.go
+++ b/backend/internal/registry/etcd_registry_test.go
@@ -1,0 +1,160 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/auto-dns/auto-dns-webui/internal/config"
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// mockEtcdClient implements the etcdClient interface with overridable Get/Delete.
+type mockEtcdClient struct {
+	getFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	delFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error)
+	deletedKey string
+}
+
+func (m *mockEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return m.getFunc(ctx, key, opts...)
+}
+
+func (m *mockEtcdClient) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	if m.delFunc != nil {
+		return m.delFunc(ctx, key, opts...)
+	}
+	m.deletedKey = key
+	return &clientv3.DeleteResponse{Deleted: 1}, nil
+}
+
+func (m *mockEtcdClient) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Txn(ctx context.Context) clientv3.Txn { return nil }
+func (m *mockEtcdClient) Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Close() error { return nil }
+
+func newTestRegistry(client etcdClient) *EtcdRegistry {
+	return NewEtcdRegistry(client, &config.EtcdConfig{PathPrefix: "/skydns"}, "testhost", zerolog.Nop())
+}
+
+func TestParseEtcdValue(t *testing.T) {
+	er := newTestRegistry(nil) // parseEtcdValue does not touch the client
+
+	t.Run("valid A record reverses domain and strips index", func(t *testing.T) {
+		rec, err := er.parseEtcdValue(
+			"/skydns/com/example/app/x1",
+			`{"host":"10.0.0.1","record_type":"a","owner_hostname":"h1","owner_container_id":"abc","owner_container_name":"web","created":"2024-01-02T03:04:05Z","force":true}`,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.Dns.Name != "app.example.com" {
+			t.Errorf("name = %q, want app.example.com", rec.Dns.Name)
+		}
+		if rec.Dns.Type != "A" {
+			t.Errorf("type = %q, want A (uppercased)", rec.Dns.Type)
+		}
+		if rec.Dns.Value != "10.0.0.1" {
+			t.Errorf("value = %q, want 10.0.0.1", rec.Dns.Value)
+		}
+		if rec.Meta.Hostname != "h1" || rec.Meta.ContainerID != "abc" || rec.Meta.ContainerName != "web" || !rec.Meta.Force {
+			t.Errorf("metadata not parsed correctly: %+v", rec.Meta)
+		}
+		if rec.Meta.Created.IsZero() {
+			t.Error("created timestamp not parsed")
+		}
+	})
+
+	t.Run("CNAME type", func(t *testing.T) {
+		rec, err := er.parseEtcdValue("/skydns/com/example/www/x1",
+			`{"host":"app.example.com","record_type":"CNAME","created":"2024-01-02T03:04:05Z"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.Dns.Type != "CNAME" || rec.Dns.Value != "app.example.com" {
+			t.Errorf("unexpected CNAME parse: %+v", rec.Dns)
+		}
+	})
+
+	errorCases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"missing record_type", "/skydns/com/example/app/x1", `{"host":"10.0.0.1","created":"2024-01-02T03:04:05Z"}`},
+		{"missing host", "/skydns/com/example/app/x1", `{"record_type":"A","created":"2024-01-02T03:04:05Z"}`},
+		{"bad created", "/skydns/com/example/app/x1", `{"host":"10.0.0.1","record_type":"A","created":"not-a-time"}`},
+		{"invalid json", "/skydns/com/example/app/x1", `{not json}`},
+	}
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := er.parseEtcdValue(tc.key, tc.value); err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	t.Run("parses valid records and skips invalid ones", func(t *testing.T) {
+		client := &mockEtcdClient{
+			getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+				return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+					{Key: []byte("/skydns/com/example/app/x1"), Value: []byte(`{"host":"10.0.0.1","record_type":"A","created":"2024-01-02T03:04:05Z"}`)},
+					{Key: []byte("/skydns/com/example/bad/x1"), Value: []byte(`{bad json}`)},
+				}}, nil
+			},
+		}
+		recs, err := newTestRegistry(client).List(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(recs) != 1 {
+			t.Fatalf("got %d records, want 1 (the invalid one should be skipped)", len(recs))
+		}
+		if recs[0].Dns.Name != "app.example.com" {
+			t.Errorf("name = %q, want app.example.com", recs[0].Dns.Name)
+		}
+	})
+
+	t.Run("propagates get error", func(t *testing.T) {
+		client := &mockEtcdClient{
+			getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+				return nil, context.DeadlineExceeded
+			},
+		}
+		if _, err := newTestRegistry(client).List(context.Background()); err == nil {
+			t.Fatal("expected error to propagate from client.Get")
+		}
+	})
+}
+
+func TestRemove(t *testing.T) {
+	client := &mockEtcdClient{
+		getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+			return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+				{Key: []byte("/skydns/com/example/app/x1"), Value: []byte(`{"host":"10.0.0.1","record_type":"A","owner_hostname":"h1","owner_container_name":"web","created":"2024-01-02T03:04:05Z"}`)},
+			}}, nil
+		},
+	}
+	rec := &dns.Record{
+		Dns:  dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"},
+		Meta: dns.RecordMetadata{Hostname: "h1", ContainerName: "web"},
+	}
+	if err := newTestRegistry(client).Remove(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.deletedKey != "/skydns/com/example/app/x1" {
+		t.Errorf("deleted key = %q, want /skydns/com/example/app/x1", client.deletedKey)
+	}
+}


### PR DESCRIPTION
## Summary

First backend test suite — establishes the testing discipline this repo lacked (it had zero `_test.go` files). All tests use mocks; no live etcd required.

- **`internal/config`** — table-driven `validate()` coverage: valid config, case-insensitive log level, MCP-port-required-when-enabled, and every error branch.
- **`internal/registry`** — `parseEtcdValue` (domain-label reversal, `xN` index stripping, type upper-casing, and the missing-`record_type`/missing-`host`/bad-`created`/invalid-JSON error paths), `List` (skips invalid records, propagates `Get` errors), and `Remove` — all against a mock `etcdClient`.
- **`internal/api`** — `/api/records` success (JSON body + content-type) and registry-error → 500.
- **`internal/mcp`** — `list_dns_records` (name/type/hostname filters + combinations), `get_dns_record` (FQDN trailing-dot + case normalization), `get_records_by_host` (subset + empty-hostname error), and registry-error → `IsError` result.

## Verification

`go test ./...`, `go test -race ./...`, and `go vet ./...` all pass locally.

Coverage of the tested packages: **api 100%, mcp 83%, registry 62%, config 41%**.

## Notes / follow-ups

- `config.Load()` (viper global state) and `registry.LockTransaction` are the main untested paths. `Remove`/`LockTransaction` are unused in this read-only app and are slated for removal in #19 — if that lands, the `Remove` test goes with it and registry coverage rises.

## Checklist

- [x] Branched off and targets the `v0.5.0` milestone branch
- [x] `go test -race ./...` and `go vet ./...` pass
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyxQ5Fi3vmBQ5odhqPREmo)_