### PR TITLE
Release v0.5.0 — foundations &amp; test suite

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: Report a defect in existing behavior
+title: ""
+labels: bug
+assignees: ""
+---
+
+## Summary
+
+<!-- A clear, concise description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+## Actual behavior
+
+## Environment
+
+- auto-dns-webui version / image tag:
+- `docker-coredns-sync` version (the producer of the etcd records):
+- etcd / CoreDNS version (if relevant):
+- Deployment (Docker Compose, k8s, bare binary):
+
+## Logs / config
+
+<!-- Relevant log lines (set AUTO_DNS_WEBUI_LOG_LEVEL=DEBUG) and any non-secret config. -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: docker-coredns-sync (upstream producer)
+    url: https://github.com/auto-dns/docker-coredns-sync/issues
+    about: If the issue is about how DNS records are produced/written into etcd, file it upstream.
+  - name: Contributing guide
+    url: https://github.com/auto-dns/auto-dns-webui/blob/main/CONTRIBUTING.md
+    about: Versioning, milestone/feature branching, and PR conventions.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,31 @@
+---
+name: Feature request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Goal
+
+<!-- What do you want to be able to do, and why? A user story is great:
+"As a <role>, I want <capability>, so that <benefit>." -->
+
+## Proposed scope
+
+- [ ]
+- [ ]
+
+## Dependencies / impact
+
+<!--
+- Does this change our public contract (API `/api/*`, config `AUTO_DNS_WEBUI_*`,
+  MCP tool schemas)? If so, note the likely SemVer bump.
+- Does it depend on a change in `docker-coredns-sync` (e.g. a new etcd key or
+  schema field)? Link the upstream issue if so.
+- Related issues:
+-->
+
+## Target milestone (version)
+
+<!-- e.g. v0.6.0 — see CONTRIBUTING.md "Milestones are versions". -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,36 @@
+version: 2
+updates:
+  # Backend Go modules
+  - package-ecosystem: gomod
+    directory: /backend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+    commit-message:
+      prefix: "chore(deps)"
+
+  # Frontend npm packages
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - security
+    commit-message:
+      prefix: "chore(deps)"
+
+  # GitHub Actions used by the workflows
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "chore(ci)"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,19 @@
+## Summary
+
+<!-- What does this change and why? -->
+
+## Linked issues
+
+<!--
+Use a GitHub closing keyword so the issue gets the `awaiting-release` label when
+this PR merges into a milestone branch, and auto-closes when the milestone branch
+merges to main. e.g. "Closes #123".
+-->
+Closes #
+
+## Checklist
+
+- [ ] Branched off the target **milestone branch** (`vMAJOR.MINOR.PATCH`) and targets it (not `main`)
+- [ ] `make check` passes (lint + typecheck + test, backend and frontend)
+- [ ] Updated `CHANGELOG.md` under `## [Unreleased]`
+- [ ] Noted any change to the minimum compatible `docker-coredns-sync` version (if the consumed etcd schema is affected)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,9 @@ jobs:
         run: make vet
 
       - name: Lint (golangci-lint)
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          version: latest
+          version: v2.12.2
           working-directory: backend
 
       - name: Test (race)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,79 @@
+name: CI
+
+# Runs the quality gates on every PR and on pushes to the default and milestone
+# branches. The release build lives in docker.yaml (tag-triggered) and is not
+# duplicated here.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - 'v*' # milestone / integration branches
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  backend:
+    name: Backend (vet, lint, test)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Build
+        working-directory: backend
+        run: go build ./...
+
+      - name: Vet
+        run: make vet
+
+      - name: Lint (golangci-lint)
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+          working-directory: backend
+
+      - name: Test (race)
+        run: make test-race
+
+  frontend:
+    name: Frontend (lint, typecheck, build)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint (eslint)
+        run: npm run lint
+
+      - name: Typecheck (tsc)
+        run: npm run typecheck
+
+      - name: Build
+        run: npm run build

--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -1,0 +1,72 @@
+name: Security
+
+# Vulnerability scanning for the Go backend (govulncheck) and the npm frontend
+# (npm audit). Runs on PRs that touch dependencies, on pushes to the default and
+# milestone branches, on a weekly schedule, and on demand.
+on:
+  pull_request:
+    paths:
+      - backend/go.mod
+      - backend/go.sum
+      - frontend/package.json
+      - frontend/package-lock.json
+      - .github/workflows/security.yaml
+  push:
+    branches:
+      - main
+      - 'v*'
+  schedule:
+    - cron: '0 6 * * 1' # Mondays 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  govulncheck:
+    name: Backend (govulncheck)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: backend/go.mod
+          cache-dependency-path: backend/go.sum
+
+      - name: Install govulncheck
+        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+
+      - name: Run govulncheck
+        working-directory: backend
+        run: govulncheck ./...
+
+  npm-audit:
+    name: Frontend (npm audit)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Fail only on high/critical advisories with a fix available. Build-time
+      # dev-only advisories without a patch are documented in the PR that
+      # introduced the exception (see CONTRIBUTING.md / PR history).
+      - name: Audit production dependencies
+        run: npm audit --omit=dev --audit-level=high

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,60 @@
+# AGENTS.md
+
+Guidance for coding agents (Codex, etc.) working in this repository. The
+authoritative, detailed guide is **[`CLAUDE.md`](./CLAUDE.md)** — read it for the
+full architecture and data flow. This file mirrors the essentials so agents have
+a single, consistent contract. Keep the two in sync when either changes.
+
+## What this is
+
+A **read-only** web UI + optional MCP server for browsing the DNS records that
+[`docker-coredns-sync`](https://github.com/auto-dns/docker-coredns-sync) writes
+into etcd (SkyDNS/CoreDNS format). Go backend in `backend/`, React + Vite
+frontend in `frontend/` (embedded into the binary for production).
+
+## Build, run & quality
+
+```bash
+make dev       # Vite (:5173) + Go backend (:8080), backend proxies to Vite
+make prod      # build frontend and embed it into the Go binary
+make check     # lint + typecheck + test for backend and frontend (run before every PR)
+```
+
+(The `make check`/`test`/`lint` targets and the test suites are being introduced
+in the foundations milestone; until then run `go test ./...` and the `npm`
+scripts directly.) The etcd client is abstracted behind an `etcdClient` interface
+in `backend/internal/registry/`, so the registry is testable with mocks — no live
+etcd required. See `CLAUDE.md` for the full architecture and `TESTS.md` for manual
+cases.
+
+## SDLC — versioning, milestones & branches
+
+This app is a **downstream consumer** of the etcd record schema produced by
+`docker-coredns-sync`; version bumps are dependency-aware. Full rules in
+[`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
+- **SemVer, dependency-aware.** MAJOR = breaking change to our public contract
+  (HTTP API `/api/*`, config `AUTO_DNS_WEBUI_*`, MCP tool schemas) **or** dropping
+  compatibility with an etcd schema older `docker-coredns-sync` versions still
+  write; MINOR = backward-compatible features; PATCH = backward-compatible fixes /
+  tooling / docs. Update `CHANGELOG.md` under `## [Unreleased]` in the same change,
+  and note the minimum compatible `docker-coredns-sync` version when the consumed
+  schema is involved.
+- **Milestones are versions.** Each milestone is a SemVer version (e.g. `v0.5.0`)
+  grouping the issues that ship in it.
+- **Branching model.** `main` is stable. A milestone is integrated on a branch
+  named for its version, `vMAJOR.MINOR.PATCH`, branched off `main`. **Feature/fix
+  branches branch off the milestone branch** and **merge back into it**; the
+  milestone branch later merges into `main` and is tagged. Never commit features
+  straight to `main` or to a milestone branch — use a feature branch.
+- **Releases.** Pushing a `vMAJOR.MINOR.PATCH` tag triggers
+  `.github/workflows/docker.yaml` (GHCR image + GitHub Release from the matching
+  CHANGELOG section). Rename `## [Unreleased]` to the versioned heading before
+  tagging.
+
+## Pull requests
+
+- Branch off, and target, the relevant **milestone branch** (`vMAJOR.MINOR.PATCH`),
+  not `main` — unless merging a finished milestone branch into `main`.
+- Link issues with `Closes #N` / `Fixes #N` / `Resolves #N`.
+- Run `make check` and update `CHANGELOG.md` before opening the PR.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Frontend npm scripts (`lint`, `lint:fix`, `typecheck`, `format`, `format:check`), an ESLint flat config (`eslint.config.js`) using `typescript-eslint` + react-hooks, and Prettier config (`.prettierrc.json` / `.prettierignore`).
 - CI workflow (`.github/workflows/ci.yaml`) running backend (build, vet, golangci-lint, race tests) and frontend (lint, typecheck, build) jobs on pull requests and pushes to `main`/`v*` branches.
 - Dependency and vulnerability automation: `.github/dependabot.yml` (gomod, npm, github-actions) and `.github/workflows/security.yaml` running `govulncheck` (backend) and `npm audit` (frontend) on a schedule and on dependency changes.
+- Backend unit tests for config validation, the etcd registry (`parseEtcdValue`, `List`, `Remove`) via a mocked etcd client, the `/api/records` handler, and the MCP tools (`list_dns_records`, `get_dns_record`, `get_records_by_host`).
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - CI workflow (`.github/workflows/ci.yaml`) running backend (build, vet, golangci-lint, race tests) and frontend (lint, typecheck, build) jobs on pull requests and pushes to `main`/`v*` branches.
 - Dependency and vulnerability automation: `.github/dependabot.yml` (gomod, npm, github-actions) and `.github/workflows/security.yaml` running `govulncheck` (backend) and `npm audit` (frontend) on a schedule and on dependency changes.
 - Backend unit tests for config validation, the etcd registry (`parseEtcdValue`, `List`, `Remove`) via a mocked etcd client, the `/api/records` handler, and the MCP tools (`list_dns_records`, `get_dns_record`, `get_records_by_host`).
+- Frontend unit tests (Vitest) for the `utils/` logic (`object`, `record`, `sort`, `filters`, `url`), wired into `make test-frontend`, plus a `TESTS.md` documenting automated and manual test cases.
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Pull request template and issue templates (bug report, feature request) under `.github/`.
 - Makefile quality gates: `check`, `lint`, `vet`, `typecheck`, `format`, `test`, `test-race`, `test-coverage`, `test-coverage-html` (backend uses `go`/`golangci-lint`; frontend delegates to npm scripts).
 - Frontend npm scripts (`lint`, `lint:fix`, `typecheck`, `format`, `format:check`), an ESLint flat config (`eslint.config.js`) using `typescript-eslint` + react-hooks, and Prettier config (`.prettierrc.json` / `.prettierignore`).
+- CI workflow (`.github/workflows/ci.yaml`) running backend (build, vet, golangci-lint, race tests) and frontend (lint, typecheck, build) jobs on pull requests and pushes to `main`/`v*` branches.
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CONTRIBUTING.md` documenting the SDLC: dependency-aware SemVer, milestones-as-versions, the milestone/feature branching model, the issue/label lifecycle, and PR conventions.
+- Pull request template and issue templates (bug report, feature request) under `.github/`.
+
 ## [0.1.8] - 2026-05-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- `CLAUDE.md` and `AGENTS.md`: architecture/data-flow overview and the SDLC (dependency-aware SemVer, milestones-as-versions, milestone/feature branching, PR conventions) for coding agents and contributors.
+
 ## [0.1.8] - 2026-05-15
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-06-25
+
 ### Added
 - `CONTRIBUTING.md` documenting the SDLC: dependency-aware SemVer, milestones-as-versions, the milestone/feature branching model, the issue/label lifecycle, and PR conventions.
 - `CLAUDE.md` and `AGENTS.md`: architecture/data-flow overview and the same SDLC for coding agents and contributors.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `CONTRIBUTING.md` documenting the SDLC: dependency-aware SemVer, milestones-as-versions, the milestone/feature branching model, the issue/label lifecycle, and PR conventions.
 - `CLAUDE.md` and `AGENTS.md`: architecture/data-flow overview and the same SDLC for coding agents and contributors.
 - Pull request template and issue templates (bug report, feature request) under `.github/`.
+- Makefile quality gates: `check`, `lint`, `vet`, `typecheck`, `format`, `test`, `test-race`, `test-coverage`, `test-coverage-html` (backend uses `go`/`golangci-lint`; frontend delegates to npm scripts).
+- Frontend npm scripts (`lint`, `lint:fix`, `typecheck`, `format`, `format:check`), an ESLint flat config (`eslint.config.js`) using `typescript-eslint` + react-hooks, and Prettier config (`.prettierrc.json` / `.prettierignore`).
+
+### Changed
+- `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.
 
 ## [0.1.8] - 2026-05-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,18 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Makefile quality gates: `check`, `lint`, `vet`, `typecheck`, `format`, `test`, `test-race`, `test-coverage`, `test-coverage-html` (backend uses `go`/`golangci-lint`; frontend delegates to npm scripts).
 - Frontend npm scripts (`lint`, `lint:fix`, `typecheck`, `format`, `format:check`), an ESLint flat config (`eslint.config.js`) using `typescript-eslint` + react-hooks, and Prettier config (`.prettierrc.json` / `.prettierignore`).
 - CI workflow (`.github/workflows/ci.yaml`) running backend (build, vet, golangci-lint, race tests) and frontend (lint, typecheck, build) jobs on pull requests and pushes to `main`/`v*` branches.
+- Dependency and vulnerability automation: `.github/dependabot.yml` (gomod, npm, github-actions) and `.github/workflows/security.yaml` running `govulncheck` (backend) and `npm audit` (frontend) on a schedule and on dependency changes.
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.
 - `frontend/package.json` version bumped from the stale `0.1.0` to `0.5.0` to track the active development line.
+- CI: upgraded `golangci/golangci-lint-action` v6 → v8 (pinned golangci-lint `v2.12.2`) so the linter binary is built with a Go toolchain compatible with the module's Go version (v6 shipped a go1.24-built binary that refused to run against the go1.26 module).
+
+### Fixed
+- Handle the JSON encode error in the `/api/records` handler (log on failure) instead of ignoring it, and explicitly ignore the (non-failing) `viper.BindPFlag` return values in CLI flag binding — resolving the `errcheck` findings that `golangci-lint` now reports.
+
+### Security
+- Bumped the Go toolchain `1.26.3` → `1.26.4`, remediating two *called* standard-library vulnerabilities flagged by `govulncheck`: `GO-2026-5039` (net/textproto) and `GO-2026-5037` (crypto/x509), both fixed in go1.26.4.
 
 ## [0.4.1] - 2026-05-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+> **Versioning note.** The published tags jump from `0.1.8` to `0.4.1`; versions
+> `0.2.0`–`0.4.0` were never tagged or released. `0.4.1` was the first release cut
+> after `0.1.8` and shipped CI/release tooling only (see its entry below). The
+> **git tag is the authoritative version** for a release — the GHCR image and
+> GitHub Release are built from it. `frontend/package.json`'s `version` tracks the
+> in-development line and is not the release source of truth. The active
+> development line is `0.5.x`. As a **downstream consumer** of the
+> [`docker-coredns-sync`](https://github.com/auto-dns/docker-coredns-sync) etcd
+> record schema, releases note the minimum compatible producer version when the
+> consumed schema is involved (see `CONTRIBUTING.md`).
+
 ## [Unreleased]
 
 ### Added
@@ -16,6 +27,19 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Changed
 - `frontend/tsconfig.json`: `moduleResolution` set to `bundler` and `skipLibCheck` enabled so `tsc --noEmit` type-checks cleanly against Vite and third-party types.
+- `frontend/package.json` version bumped from the stale `0.1.0` to `0.5.0` to track the active development line.
+
+## [0.4.1] - 2026-05-17
+
+First release cut after `0.1.8` (see the versioning note above). Shipped
+CI/release tooling only — no application behavior changes.
+
+### Added
+- Automated GitHub Releases from CI: on tag push, release notes are extracted from the matching `## [VERSION]` CHANGELOG section and the Docker pull command is appended.
+
+### Fixed
+- Corrected YAML literal-block indentation in the release workflow's "Create GitHub release" step.
+- Used the full image reference (instead of a bare digest) as the `docker buildx imagetools create` source so the major/minor/latest tag push for stable releases succeeds.
 
 ## [0.1.8] - 2026-05-15
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,156 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with
+code in this repository.
+
+## What this is
+
+`auto-dns-webui` is a **read-only** web UI — plus an optional MCP server — for
+browsing the DNS records that
+[`docker-coredns-sync`](https://github.com/auto-dns/docker-coredns-sync) writes
+into etcd in [SkyDNS/CoreDNS format](https://coredns.io/plugins/etcd/). It does
+not create or mutate records; it reads what the upstream producer wrote.
+
+The repo is two halves:
+
+- **`backend/`** — a Go service (Cobra + Viper) that reads etcd and serves
+  `GET /api/records`, serves the embedded React SPA, and optionally runs an MCP
+  server.
+- **`frontend/`** — a React + TypeScript + Vite SPA (SCSS modules) that renders
+  the record list with client-side search/filter/sort.
+
+For production the built frontend is embedded into the Go binary via `go:embed`.
+
+## Build & Run
+
+```bash
+# Dev: Vite (:5173) + Go backend (:8080) with the backend reverse-proxying to Vite
+make dev
+
+# Build the Go backend in dev mode (no embedded frontend)
+make build
+
+# Full production build: build the frontend and embed it into the Go binary
+make prod
+
+# Run the production binary locally
+make run-prod
+```
+
+The backend can be configured by env vars (`AUTO_DNS_WEBUI_*`), a `config.yaml`,
+or CLI flags (precedence: flags → env → file → defaults). See the README for the
+full configuration reference.
+
+## Testing & quality
+
+> Note: a test suite and the `make` targets below are being introduced as part of
+> the foundations milestone (see the open issues). Until they land, run the
+> underlying `go test` / `npm` commands directly.
+
+```bash
+make check         # lint + typecheck + test for backend and frontend (pre-PR gate)
+make test          # go test ./... (backend) and frontend unit tests
+make lint          # golangci-lint (backend) + eslint (frontend)
+make format        # gofmt + goimports (backend) + prettier (frontend)
+```
+
+Docker/etcd should be exercised through mocks where possible — the etcd client is
+already abstracted behind an `etcdClient` interface in
+`backend/internal/registry/etcd_registry.go`, which makes the registry testable
+without a live etcd. Manual integration cases live in `TESTS.md`.
+
+## Development environment
+
+A devcontainer is provided in `.devcontainer/` with an etcd instance wired up via
+Docker Compose. `post-create.sh` installs frontend deps and seeds etcd with test
+records (`scripts/seed-etcd.sh`). Inspect etcd directly with:
+
+```bash
+etcdctl --endpoints http://etcd:2379 get --prefix /skydns
+```
+
+## Architecture
+
+### Data flow
+
+1. **`backend/cmd/auto-dns-webui/root.go`** — Cobra CLI entrypoint. Loads config
+   via Viper, sets up signal handling, and runs the app.
+2. **`backend/internal/config/config.go`** — Viper config: `app`, `etcd`, `log`,
+   `server` (incl. dev `proxy`), and `mcp`. `Load()` unmarshals and `validate()`
+   enforces required values.
+3. **`backend/internal/app/app.go`** — Wires dependencies: creates the etcd
+   client + `EtcdRegistry`, the API handler, the HTTP `Server`, and (if
+   `mcp.enabled`) a second `http.Server` for the MCP handler. `Run` starts the
+   HTTP server and, optionally, the MCP server, with graceful shutdown on context
+   cancel.
+4. **`backend/internal/registry/etcd_registry.go` (`EtcdRegistry`)** — Reads etcd
+   under the configured `path_prefix` (default `/skydns`). `parseEtcdValue`
+   reconstructs the FQDN by stripping the prefix and the trailing `xN` index
+   segment and **reversing** the remaining domain labels, then unmarshals the
+   JSON value (`host`, `record_type`, `owner_hostname`, `owner_container_id`,
+   `owner_container_name`, `created`, `force`) into a `dns.Record`. `List` is the
+   only method the app actually calls. (`Remove`/`LockTransaction` exist but are
+   currently unused — see the open tech-debt issue.)
+5. **`backend/internal/api/handlers.go`** — `Records` calls `Registry.List` and
+   writes the records as JSON to `GET /api/records`.
+6. **`backend/internal/server/server.go`** — Registers `/api/records` and mounts
+   the frontend: a reverse proxy to Vite in dev (`proxy.enable`) or the embedded
+   static files in prod.
+7. **`backend/internal/mcp/`** — `handler.go` builds a streamable HTTP MCP server;
+   `tools.go` registers three **read-only** tools: `list_dns_records` (filter by
+   name substring / type / hostname), `get_dns_record` (exact FQDN), and
+   `get_records_by_host` (by producing hostname). All filtering is in-memory after
+   `Registry.List`.
+8. **`frontend/src/pages/RecordList/RecordList.tsx`** — Fetches `/api/records`
+   once on mount; all search, filtering, faceting, and multi-field sorting happen
+   client-side in `frontend/src/utils/`. Filter/sort state is persisted in the URL
+   query string (`utils/url.ts`).
+
+### Key types
+
+- **`dns.Record`** (`backend/internal/dns/record.go`) — `Dns` (name/type/value)
+  plus `Meta` (container id/name, created, owner hostname, force). The TypeScript
+  mirror is `RecordEntry` in `frontend/src/types/index.ts`.
+- **etcd key format** — `{path_prefix}/{reversed-domain}/x{index}`, e.g.
+  `/skydns/com/example/app/x1`. The producer of these keys is
+  `docker-coredns-sync`; this app only reads them.
+
+## Versioning, branches & releases
+
+This app is a **downstream consumer** of the etcd record schema produced by
+`docker-coredns-sync`, so versioning is dependency-aware. See `CONTRIBUTING.md`
+for the full guide. Key conventions:
+
+- **Versioning:** [SemVer](https://semver.org/). MAJOR = a breaking change to our
+  public contract (HTTP API `/api/*`, config `AUTO_DNS_WEBUI_*`, MCP tool
+  schemas) **or** dropping compatibility with an etcd schema older
+  `docker-coredns-sync` versions still write; MINOR = backward-compatible
+  features; PATCH = backward-compatible fixes and tooling/docs. Record changes in
+  `CHANGELOG.md` (Keep a Changelog) under `## [Unreleased]` in the same PR, and
+  note the minimum compatible `docker-coredns-sync` version when the consumed
+  schema is involved.
+- **Milestones are versions:** each milestone is a SemVer version (e.g. `v0.5.0`)
+  that groups the issues shipping in it.
+- **Branches:** `main` is stable. A milestone is integrated on a branch named for
+  its version, `vMAJOR.MINOR.PATCH` (branched off `main`). **Feature/fix branches
+  branch off the milestone branch** (`feat/...`, `fix/...`, `chore/...`,
+  `docs/...`) and **merge back into the milestone branch.** When the milestone
+  branch is green it merges into `main` and is tagged.
+- **Tags & releases:** pushing a tag `vMAJOR.MINOR.PATCH` (pre-release:
+  `-SUFFIX`) triggers `.github/workflows/docker.yaml`, which builds/pushes the
+  GHCR image and cuts a GitHub Release from the matching `## [MAJOR.MINOR.PATCH]`
+  CHANGELOG section. Rename `## [Unreleased]` to the versioned heading before
+  tagging.
+
+## Pull request conventions
+
+- **Branch off, and target, the milestone branch** (`vMAJOR.MINOR.PATCH`), not
+  `main` — unless merging a completed milestone branch into `main`.
+- Link issues with closing keywords in the PR body — `Closes #N` / `Fixes #N` /
+  `Resolves #N`. Merging into a milestone branch labels the issue
+  `awaiting-release`; the keyword auto-closes it when the milestone branch merges
+  to `main`.
+- **Issue state** encodes pipeline position: open without `awaiting-release` =
+  open for development; open + `awaiting-release` = merged to a milestone branch,
+  not yet released; closed = released.
+- Run `make check` and update `CHANGELOG.md` before opening the PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,154 @@
+# Contributing
+
+Thanks for contributing to `auto-dns-webui` — a read-only web UI (and optional
+MCP server) for browsing the DNS records that
+[`docker-coredns-sync`](https://github.com/auto-dns/docker-coredns-sync) writes
+into etcd for CoreDNS. This guide documents the project's conventions for
+versioning, milestones, branches, tags, issues, and pull requests.
+
+> Licensing note: this project uses a [custom MIT-NC license](./LICENSE)
+> (non-commercial). By contributing you agree your contributions are licensed
+> under the same terms.
+
+## Development quickstart
+
+The repo is split into a Go backend (`backend/`) and a React + Vite frontend
+(`frontend/`). For production the built frontend is embedded into the Go binary.
+
+```bash
+make dev      # Vite (:5173) + Go backend (:8080) with reverse proxy, hot reload
+make prod     # build frontend and embed it into the Go binary
+make check    # lint + typecheck + test for backend and frontend (run before every PR)
+```
+
+See `CLAUDE.md` / `AGENTS.md` for an architecture overview and the data flow from
+etcd → backend → UI/MCP.
+
+## Versioning (SemVer, dependency-aware)
+
+The project follows [Semantic Versioning](https://semver.org/)
+(`MAJOR.MINOR.PATCH`) and records all notable changes in `CHANGELOG.md`
+following [Keep a Changelog](https://keepachangelog.com/). **Add your entry under
+the `## [Unreleased]` heading in the same PR as your change.**
+
+Because this app sits in a dependency chain, decide the bump by considering both
+**its own public contract** and the **upstream/downstream projects** it
+integrates with:
+
+- **This app's public contract** is: the HTTP API (`/api/*`), the configuration
+  surface (`AUTO_DNS_WEBUI_*` env vars / `config.yaml` keys / CLI flags), the MCP
+  tool names and schemas, and the published Docker image behavior.
+- **Upstream (what we consume):** `docker-coredns-sync` (the producer of the
+  etcd record schema — `host`, `record_type`, `owner_*`, `created`, `force`),
+  and below it CoreDNS + etcd / the SkyDNS key format. We are a **downstream
+  consumer** of that schema.
+- **Sibling/peer services** in the same homelab stack (e.g. `pihole`,
+  reverse-proxy/forward-auth) inform compatibility expectations for auth and
+  deployment.
+
+Rules of thumb:
+
+| Bump | When |
+|------|------|
+| **MAJOR** | A breaking change to *our* public contract (renamed/removed config key, changed API/MCP schema), **or** dropping compatibility with an etcd record schema that older `docker-coredns-sync` versions still write. |
+| **MINOR** | Backward-compatible features: new endpoints, UI features, MCP tools, new *optional* config, or support for a new upstream schema field while still reading the old shape. |
+| **PATCH** | Backward-compatible bug fixes and internal/tooling/doc changes with no contract change. |
+
+Every release's CHANGELOG entry SHOULD note the **minimum compatible
+`docker-coredns-sync` version** (and any CoreDNS/etcd expectations) it was tested
+against, since our correctness depends on that upstream schema.
+
+The active version line continues from the latest published release (`0.4.x`).
+
+## Milestones are versions
+
+**Each milestone is a SemVer version** (e.g. `v0.5.0`, `v0.6.0`, `v1.0.0`), not a
+free-form label. A milestone groups the issues that will ship together in that
+version. Choose the milestone's version using the SemVer rules above (the largest
+bump among its issues wins — one breaking change in the group makes the whole
+milestone a MAJOR).
+
+When you file or triage an issue, assign it to the milestone (version) it targets.
+
+## Branches
+
+`main` is the default, stable branch. We use a two-level branching model:
+
+1. **Milestone / integration branch** — named exactly for the version,
+   `vMAJOR.MINOR.PATCH` (e.g. `v0.5.0`). It is branched off `main` and is where a
+   milestone's work is integrated. **This branch is the milestone.**
+2. **Feature / fix branches** — branched off the **milestone branch** (not
+   `main`), named `feat/...`, `fix/...`, `chore/...`, or `docs/...`. Each feature
+   is developed on its own branch and **merged back into the milestone branch**.
+
+```
+main
+ └── v0.5.0                 # milestone/integration branch (branched from main)
+      ├── docs/contributing-and-sdlc   # feature branch → merged into v0.5.0
+      ├── docs/agent-guides            # feature branch → merged into v0.5.0
+      └── ci/add-pipeline              # feature branch → merged into v0.5.0
+```
+
+When the milestone branch is complete and green, it is merged into `main` and
+tagged (see below). A standalone hotfix that isn't part of a planned milestone
+still gets its own `vMAJOR.MINOR.PATCH` branch off `main`.
+
+## Tags & releases
+
+Releases are cut by pushing a git tag once the milestone branch has merged to
+`main`:
+
+- Stable: `vMAJOR.MINOR.PATCH` (e.g. `v0.5.0`).
+- Pre-release: `vMAJOR.MINOR.PATCH-SUFFIX` (e.g. `v0.5.0-rc.1`).
+
+Pushing a matching tag triggers `.github/workflows/docker.yaml`, which:
+
+- builds and pushes the multi-arch image to GHCR, and
+- creates a GitHub Release with notes extracted from the matching
+  `## [MAJOR.MINOR.PATCH]` section of `CHANGELOG.md`.
+
+Stable (non-pre-release) tags also move the `MAJOR`, `MAJOR.MINOR`, and `latest`
+image tags. **Before tagging, rename the `## [Unreleased]` CHANGELOG section to
+`## [MAJOR.MINOR.PATCH] - YYYY-MM-DD`** — the release notes are empty if the
+section is missing.
+
+## Issues & labels
+
+Issue state encodes where work is in the release pipeline:
+
+| State | Meaning |
+|-------|---------|
+| Open, no `awaiting-release` label | Open for development |
+| Open + `awaiting-release` | Implemented and merged to a milestone branch; not yet released |
+| Closed | Released (auto-closes when the milestone branch merges to `main`) |
+
+Labels in use:
+
+| Label | Meaning |
+|-------|---------|
+| `bug` | A defect in existing behavior |
+| `enhancement` | New feature or improvement |
+| `documentation` | Docs-only change |
+| `ci` | CI/CD, workflows, automation |
+| `test` | Test coverage / test infrastructure |
+| `security` | Vulnerability remediation or hardening |
+| `tech-debt` | Cleanup, dead code, refactors with no behavior change |
+| `awaiting-release` | Merged to a milestone branch, not yet released (managed by automation) |
+
+Group issues by their target release using the **milestone (version)** they
+belong to.
+
+## Pull requests
+
+- **Target the milestone branch** (`vMAJOR.MINOR.PATCH`) the work belongs to,
+  **not `main`** — unless you are merging a completed milestone branch into
+  `main`.
+- **Branch off the milestone branch**, not `main`.
+- **Link issues with closing keywords** in the PR body: `Closes #N`, `Fixes #N`,
+  or `Resolves #N`. This drives the automation: merging into a milestone branch
+  (`v*`) labels the issue `awaiting-release`; the `Closes #N` keyword fires (and
+  auto-closes the issue) when the milestone branch merges into `main`.
+- **Run `make check`** (lint + typecheck + test for backend and frontend) before
+  opening the PR.
+- **Update `CHANGELOG.md`** under `## [Unreleased]` in the same PR, and note any
+  change to the minimum compatible `docker-coredns-sync` version.

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ COPY frontend/ .
 RUN npm install && npm run build
 
 # ===== Stage 2: Build Go Backend =====
-FROM golang:1.26.3 AS backend-builder
+FROM golang:1.26.4 AS backend-builder
 WORKDIR /backend
 COPY backend/go.mod backend/go.sum ./
 RUN go mod download

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ OUTPUT_BIN=$(BACKEND_DIR)/auto-dns-webui
 
 # --- TASKS ---
 
-.PHONY: help dev build prod run-prod clean init
+.PHONY: help dev build prod run-prod clean init \
+	check lint lint-backend lint-frontend vet typecheck \
+	format format-backend format-frontend \
+	test test-backend test-frontend test-race test-coverage test-coverage-html
 
 help:
 	@echo "Common tasks:"
@@ -15,6 +18,16 @@ help:
 	@echo "  make prod        - Build frontend and backend (with embedded static files)"
 	@echo "  make run-prod    - Run the production binary locally"
 	@echo "  make clean       - Remove generated build artifacts"
+	@echo ""
+	@echo "Quality gates (run before every PR):"
+	@echo "  make check       - vet + lint + typecheck + test (backend and frontend)"
+	@echo "  make lint        - golangci-lint (backend) + eslint (frontend)"
+	@echo "  make vet         - go vet (backend)"
+	@echo "  make typecheck   - tsc --noEmit (frontend)"
+	@echo "  make format      - gofmt/goimports (backend) + prettier (frontend)"
+	@echo "  make test        - go test (backend) + frontend unit tests"
+	@echo "  make test-race   - go test -race (backend)"
+	@echo "  make test-coverage - go test with coverage summary (backend)"
 
 dev:
 	@echo "Running dev mode: Vite + Go (with reverse proxy)"
@@ -74,3 +87,56 @@ init:
 	@echo "# Logging Configuration" >> .devcontainer/.env
 	@echo "AUTO_DNS_WEBUI_LOG_LEVEL=INFO" >> .devcontainer/.env
 	@echo "Created .devcontainer/.env with default configuration"
+
+# --- QUALITY GATES ---
+
+# Aggregate pre-PR gate. Mirrors docker-coredns-sync's `check` (lint + test),
+# extended with go vet and the frontend TypeScript typecheck. Formatting is a
+# separate, non-gating target (`make format`).
+check: vet lint typecheck test
+	@echo "All checks passed."
+
+lint: lint-backend lint-frontend
+
+lint-backend:
+	cd $(BACKEND_DIR) && golangci-lint run ./...
+
+lint-frontend:
+	npm run lint --prefix $(FRONTEND_DIR)
+
+vet:
+	cd $(BACKEND_DIR) && go vet ./...
+
+typecheck:
+	npm run typecheck --prefix $(FRONTEND_DIR)
+
+format: format-backend format-frontend
+
+format-backend:
+	cd $(BACKEND_DIR) && gofmt -w .
+	@if command -v goimports >/dev/null 2>&1; then \
+		cd $(BACKEND_DIR) && goimports -w .; \
+	else \
+		echo "goimports not installed; skipping (install: go install golang.org/x/tools/cmd/goimports@latest)"; \
+	fi
+
+format-frontend:
+	npm run format --prefix $(FRONTEND_DIR)
+
+test: test-backend test-frontend
+
+test-backend:
+	cd $(BACKEND_DIR) && go test ./...
+
+# Placeholder until the frontend test runner lands (see issue #16).
+test-frontend:
+	@echo "No frontend tests yet (see issue #16)."
+
+test-race:
+	cd $(BACKEND_DIR) && go test -race ./...
+
+test-coverage:
+	cd $(BACKEND_DIR) && go test -coverprofile=coverage.out ./... && go tool cover -func=coverage.out
+
+test-coverage-html:
+	cd $(BACKEND_DIR) && go test -coverprofile=coverage.out ./... && go tool cover -html=coverage.out -o coverage.html

--- a/Makefile
+++ b/Makefile
@@ -128,9 +128,8 @@ test: test-backend test-frontend
 test-backend:
 	cd $(BACKEND_DIR) && go test ./...
 
-# Placeholder until the frontend test runner lands (see issue #16).
 test-frontend:
-	@echo "No frontend tests yet (see issue #16)."
+	npm test --prefix $(FRONTEND_DIR)
 
 test-race:
 	cd $(BACKEND_DIR) && go test -race ./...

--- a/TESTS.md
+++ b/TESTS.md
@@ -1,0 +1,55 @@
+# Tests
+
+Automated tests run without any external services (etcd and the browser are not
+required). Manual integration cases — which need a live etcd seeded by
+`docker-coredns-sync`-style records — are listed at the bottom.
+
+## Automated
+
+```bash
+make check          # everything: backend vet/lint/test + frontend lint/typecheck/test
+make test           # backend (go test) + frontend (vitest)
+```
+
+### Backend (Go)
+
+```bash
+make test-backend       # cd backend && go test ./...
+make test-race          # go test -race ./...
+make test-coverage      # coverage function summary
+```
+
+The etcd client is abstracted behind the `etcdClient` interface
+(`backend/internal/registry/etcd_registry.go`), so the registry is tested with a
+mock — no live etcd. Current unit coverage: config validation, the registry
+(`parseEtcdValue`, `List`, `Remove`), the `/api/records` handler, and the MCP
+tools.
+
+### Frontend (Vitest)
+
+```bash
+make test-frontend          # cd frontend && npm test  (vitest run)
+npm run test:watch --prefix frontend
+```
+
+Unit tests cover the pure logic in `frontend/src/utils/` — `object`, `record`,
+`sort`, `filters`, and `url` (URL serialize/parse round-trip).
+
+## Manual integration cases
+
+These require the devcontainer (or a local etcd) seeded via
+`scripts/seed-etcd.sh`. Start the app with `make dev` and verify:
+
+1. **Record list loads.** `GET /api/records` returns the seeded records and the
+   UI renders them grouped/sorted by name.
+2. **Filtering & search.** Type/hostname/force facets and the free-text search
+   narrow the list; facet counts update.
+3. **Sorting.** Single- and multi-field sorts reorder the list; the default
+   (name asc) is omitted from the URL.
+4. **URL persistence.** Applying filters/sorts updates the query string; copying
+   the URL into a new tab restores the same view; browser back/forward works.
+5. **MCP tools** (when `AUTO_DNS_WEBUI_MCP_ENABLED=true`): `list_dns_records`
+   (with/without filters), `get_dns_record` (exact FQDN, incl. trailing dot),
+   and `get_records_by_host` return the expected subsets.
+6. **etcd unavailable.** Stop etcd and confirm `/api/records` returns 500 and the
+   UI surfaces the error (see issue #20 for the error-state work).

--- a/backend/cmd/auto-dns-webui/root.go
+++ b/backend/cmd/auto-dns-webui/root.go
@@ -69,47 +69,47 @@ var rootCmd = &cobra.Command{
 func init() {
 	// Persistent config file override
 	rootCmd.PersistentFlags().String("config", "", "Path to config file (e.g. ./config.yaml)")
-	viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
+	_ = viper.BindPFlag("config", rootCmd.PersistentFlags().Lookup("config"))
 
 	// App Flags
 	rootCmd.PersistentFlags().String("app.hostname", "", "app hostname")
-	viper.BindPFlag("app.hostname", rootCmd.PersistentFlags().Lookup("app.hostname"))
+	_ = viper.BindPFlag("app.hostname", rootCmd.PersistentFlags().Lookup("app.hostname"))
 
 	// Etcd Flags
 	rootCmd.PersistentFlags().String("etcd.host", "", "etcd host to connect to")
-	viper.BindPFlag("etcd.host", rootCmd.PersistentFlags().Lookup("etcd.host"))
+	_ = viper.BindPFlag("etcd.host", rootCmd.PersistentFlags().Lookup("etcd.host"))
 
 	rootCmd.PersistentFlags().Int("etcd.port", 0, "etcd port")
-	viper.BindPFlag("etcd.port", rootCmd.PersistentFlags().Lookup("etcd.port"))
+	_ = viper.BindPFlag("etcd.port", rootCmd.PersistentFlags().Lookup("etcd.port"))
 
 	rootCmd.PersistentFlags().String("etcd.path-prefix", "", "etcd key path prefix (e.g., /skydns)")
-	viper.BindPFlag("etcd.path_prefix", rootCmd.PersistentFlags().Lookup("etcd.path-prefix"))
+	_ = viper.BindPFlag("etcd.path_prefix", rootCmd.PersistentFlags().Lookup("etcd.path-prefix"))
 
 	rootCmd.PersistentFlags().Float64("etcd.lock_ttl", 0, "etcd lock ttl")
-	viper.BindPFlag("etcd.lock_ttl", rootCmd.PersistentFlags().Lookup("etcd.lock_ttl"))
+	_ = viper.BindPFlag("etcd.lock_ttl", rootCmd.PersistentFlags().Lookup("etcd.lock_ttl"))
 
 	rootCmd.PersistentFlags().Float64("etcd.lock_timeout", 0, "etcd lock timeout")
-	viper.BindPFlag("etcd.lock_timeout", rootCmd.PersistentFlags().Lookup("etcd.lock_timeout"))
+	_ = viper.BindPFlag("etcd.lock_timeout", rootCmd.PersistentFlags().Lookup("etcd.lock_timeout"))
 
 	rootCmd.PersistentFlags().Float64("etcd.lock_retry_interval", 0, "etcd lock retry interval")
-	viper.BindPFlag("etcd.lock_retry_interval", rootCmd.PersistentFlags().Lookup("etcd.lock_retry_interval"))
+	_ = viper.BindPFlag("etcd.lock_retry_interval", rootCmd.PersistentFlags().Lookup("etcd.lock_retry_interval"))
 
 	// Log Flags
 	rootCmd.PersistentFlags().String("log.level", "", "Log level (e.g., TRACE, DEBUG, INFO, WARN, ERROR, FATAL)")
-	viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log.level"))
+	_ = viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log.level"))
 
 	// Server Flags
 	rootCmd.PersistentFlags().Int("server.port", 0, "the server port (e.g. 8080)")
-	viper.BindPFlag("server.port", rootCmd.PersistentFlags().Lookup("server.port"))
+	_ = viper.BindPFlag("server.port", rootCmd.PersistentFlags().Lookup("server.port"))
 
 	rootCmd.PersistentFlags().Bool("server.proxy.enable", false, "enable webui proxying to a Vite server for local development")
-	viper.BindPFlag("server.proxy.enable", rootCmd.PersistentFlags().Lookup("server.proxy.enable"))
+	_ = viper.BindPFlag("server.proxy.enable", rootCmd.PersistentFlags().Lookup("server.proxy.enable"))
 
 	rootCmd.PersistentFlags().String("server.proxy.hostname", "", "the vite web server hostname (e.g. localhost)")
-	viper.BindPFlag("server.proxy.hostname", rootCmd.PersistentFlags().Lookup("server.proxy.hostname"))
+	_ = viper.BindPFlag("server.proxy.hostname", rootCmd.PersistentFlags().Lookup("server.proxy.hostname"))
 
 	rootCmd.PersistentFlags().Int("server.proxy.port", 0, "the vite web server port (e.g. 5173)")
-	viper.BindPFlag("server.proxy.port", rootCmd.PersistentFlags().Lookup("server.proxy.port"))
+	_ = viper.BindPFlag("server.proxy.port", rootCmd.PersistentFlags().Lookup("server.proxy.port"))
 }
 
 // Execute runs the root command.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,6 +1,6 @@
 module github.com/auto-dns/auto-dns-webui
 
-go 1.26.3
+go 1.26.4
 
 require go.etcd.io/etcd/client/v3 v3.6.1
 

--- a/backend/internal/api/handlers.go
+++ b/backend/internal/api/handlers.go
@@ -29,5 +29,7 @@ func (h *Handler) Records(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Header().Set("Content-Type", "application/json")
-	json.NewEncoder(w).Encode(records)
+	if err := json.NewEncoder(w).Encode(records); err != nil {
+		h.Logger.Error().Err(err).Msg("Failed to encode records response")
+	}
 }

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -1,0 +1,68 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// mockRegistry implements registry.Registry for handler tests.
+type mockRegistry struct {
+	records []*dns.Record
+	err     error
+}
+
+func (m *mockRegistry) List(ctx context.Context) ([]*dns.Record, error) { return m.records, m.err }
+func (m *mockRegistry) Remove(ctx context.Context, record *dns.Record) error { return nil }
+func (m *mockRegistry) LockTransaction(ctx context.Context, key []string, fn func() error) error {
+	return fn()
+}
+func (m *mockRegistry) Close() error { return nil }
+
+func TestRecords_Success(t *testing.T) {
+	reg := &mockRegistry{records: []*dns.Record{
+		{
+			Dns:  dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"},
+			Meta: dns.RecordMetadata{Hostname: "h1", Created: time.Now()},
+		},
+	}}
+	h := NewHandler(reg, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/records", nil)
+	rec := httptest.NewRecorder()
+	h.Records(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("content-type = %q, want application/json", ct)
+	}
+	var got []*dns.Record
+	if err := json.Unmarshal(rec.Body.Bytes(), &got); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if len(got) != 1 || got[0].Dns.Name != "app.example.com" {
+		t.Errorf("unexpected body: %s", rec.Body.String())
+	}
+}
+
+func TestRecords_RegistryError(t *testing.T) {
+	h := NewHandler(&mockRegistry{err: errors.New("etcd down")}, zerolog.Nop())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/records", nil)
+	rec := httptest.NewRecorder()
+	h.Records(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+}

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -1,0 +1,76 @@
+package config
+
+import "testing"
+
+// validConfig returns a Config that passes validate(); tests mutate one field
+// at a time to exercise each validation branch.
+func validConfig() Config {
+	return Config{
+		App:  AppConfig{Hostname: "dns1"},
+		Etcd: EtcdConfig{Host: "localhost", Port: 2379, PathPrefix: "/skydns", LockTTL: 5, LockTimeout: 2, LockRetryInterval: 0.1},
+		Log:  LoggingConfig{Level: "INFO"},
+		MCP:  MCPConfig{Enabled: false, Port: 0},
+		Server: ServerConfig{
+			Port:  8080,
+			Proxy: ProxyConfig{Enable: false, Hostname: "localhost", Port: 5173},
+		},
+	}
+}
+
+func TestValidate_Valid(t *testing.T) {
+	c := validConfig()
+	if err := c.validate(); err != nil {
+		t.Fatalf("expected valid config, got error: %v", err)
+	}
+}
+
+func TestValidate_LogLevelCaseInsensitive(t *testing.T) {
+	c := validConfig()
+	c.Log.Level = "debug"
+	if err := c.validate(); err != nil {
+		t.Fatalf("lowercase log level should be accepted, got: %v", err)
+	}
+}
+
+func TestValidate_MCPPortRequiredWhenEnabled(t *testing.T) {
+	c := validConfig()
+	c.MCP.Enabled = true
+	c.MCP.Port = 0
+	if err := c.validate(); err == nil {
+		t.Fatal("expected error when mcp.enabled but mcp.port is invalid")
+	}
+
+	c.MCP.Port = 8092
+	if err := c.validate(); err != nil {
+		t.Fatalf("expected valid config with mcp enabled + port set, got: %v", err)
+	}
+}
+
+func TestValidate_Errors(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*Config)
+	}{
+		{"empty app hostname", func(c *Config) { c.App.Hostname = "" }},
+		{"empty etcd host", func(c *Config) { c.Etcd.Host = "" }},
+		{"etcd port zero", func(c *Config) { c.Etcd.Port = 0 }},
+		{"etcd port too high", func(c *Config) { c.Etcd.Port = 70000 }},
+		{"empty path prefix", func(c *Config) { c.Etcd.PathPrefix = "" }},
+		{"lock ttl zero", func(c *Config) { c.Etcd.LockTTL = 0 }},
+		{"lock timeout zero", func(c *Config) { c.Etcd.LockTimeout = 0 }},
+		{"lock retry interval zero", func(c *Config) { c.Etcd.LockRetryInterval = 0 }},
+		{"invalid log level", func(c *Config) { c.Log.Level = "VERBOSE" }},
+		{"empty proxy hostname", func(c *Config) { c.Server.Proxy.Hostname = "" }},
+		{"proxy port zero", func(c *Config) { c.Server.Proxy.Port = 0 }},
+		{"server port too high", func(c *Config) { c.Server.Port = 99999 }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := validConfig()
+			tt.mutate(&c)
+			if err := c.validate(); err == nil {
+				t.Fatalf("%s: expected validation error, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/backend/internal/mcp/tools_test.go
+++ b/backend/internal/mcp/tools_test.go
@@ -1,0 +1,136 @@
+package mcphandler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+type mockDNSRegistry struct {
+	records []*dns.Record
+	err     error
+}
+
+func (m *mockDNSRegistry) List(ctx context.Context) ([]*dns.Record, error) {
+	return m.records, m.err
+}
+
+func sampleRecords() []*dns.Record {
+	created := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	return []*dns.Record{
+		{Dns: dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"}, Meta: dns.RecordMetadata{Hostname: "alpha", Created: created}},
+		{Dns: dns.DnsRecord{Name: "db.example.com", Type: "AAAA", Value: "fd00::1"}, Meta: dns.RecordMetadata{Hostname: "beta", Created: created}},
+		{Dns: dns.DnsRecord{Name: "www.example.com", Type: "CNAME", Value: "app.example.com"}, Meta: dns.RecordMetadata{Hostname: "alpha", Created: created}},
+	}
+}
+
+func newReq(args map[string]any) mcp.CallToolRequest {
+	var req mcp.CallToolRequest
+	req.Params.Arguments = args
+	return req
+}
+
+// decode parses the JSON text payload of a successful tool result.
+func decode(t *testing.T, res *mcp.CallToolResult) listRecordsOut {
+	t.Helper()
+	if res.IsError {
+		t.Fatalf("tool returned an error result: %v", res.Content)
+	}
+	tc, ok := res.Content[0].(mcp.TextContent)
+	if !ok {
+		t.Fatalf("content[0] is not TextContent: %T", res.Content[0])
+	}
+	var out listRecordsOut
+	if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+		t.Fatalf("result text is not valid JSON: %v", err)
+	}
+	return out
+}
+
+func TestListDNSRecords_Filters(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeListDNSRecords(d)
+
+	tests := []struct {
+		name string
+		args map[string]any
+		want int
+	}{
+		{"no filter returns all", map[string]any{}, 3},
+		{"type filter A", map[string]any{"type": "a"}, 1},
+		{"name substring", map[string]any{"name": "EXAMPLE"}, 3},
+		{"name substring narrow", map[string]any{"name": "db"}, 1},
+		{"hostname filter", map[string]any{"hostname": "alpha"}, 2},
+		{"combined type+hostname", map[string]any{"type": "CNAME", "hostname": "alpha"}, 1},
+		{"no match", map[string]any{"hostname": "ghost"}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res, err := handler(context.Background(), newReq(tt.args))
+			if err != nil {
+				t.Fatalf("handler error: %v", err)
+			}
+			out := decode(t, res)
+			if out.Total != tt.want || len(out.Records) != tt.want {
+				t.Errorf("total = %d (records %d), want %d", out.Total, len(out.Records), tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDNSRecord_NormalizesTrailingDot(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeGetDNSRecord(d)
+
+	res, err := handler(context.Background(), newReq(map[string]any{"name": "APP.example.com."}))
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	out := decode(t, res)
+	if out.Total != 1 || out.Records[0].Name != "app.example.com" {
+		t.Errorf("expected exactly app.example.com, got %+v", out.Records)
+	}
+}
+
+func TestGetRecordsByHost(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{records: sampleRecords()}, Logger: zerolog.Nop()}
+	handler := makeGetRecordsByHost(d)
+
+	t.Run("returns host subset", func(t *testing.T) {
+		res, err := handler(context.Background(), newReq(map[string]any{"hostname": "alpha"}))
+		if err != nil {
+			t.Fatalf("handler error: %v", err)
+		}
+		if out := decode(t, res); out.Total != 2 {
+			t.Errorf("total = %d, want 2", out.Total)
+		}
+	})
+
+	t.Run("missing hostname is an error", func(t *testing.T) {
+		res, err := handler(context.Background(), newReq(map[string]any{}))
+		if err != nil {
+			t.Fatalf("handler returned transport error: %v", err)
+		}
+		if !res.IsError {
+			t.Error("expected IsError result when hostname is empty")
+		}
+	})
+}
+
+func TestListDNSRecords_RegistryError(t *testing.T) {
+	d := Deps{Registry: &mockDNSRegistry{err: errors.New("etcd down")}, Logger: zerolog.Nop()}
+	res, err := makeListDNSRecords(d)(context.Background(), newReq(map[string]any{}))
+	if err != nil {
+		t.Fatalf("handler returned transport error: %v", err)
+	}
+	if !res.IsError {
+		t.Error("expected IsError result when registry.List fails")
+	}
+}

--- a/backend/internal/registry/etcd_registry_test.go
+++ b/backend/internal/registry/etcd_registry_test.go
@@ -1,0 +1,160 @@
+package registry
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rs/zerolog"
+	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
+	clientv3 "go.etcd.io/etcd/client/v3"
+
+	"github.com/auto-dns/auto-dns-webui/internal/config"
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// mockEtcdClient implements the etcdClient interface with overridable Get/Delete.
+type mockEtcdClient struct {
+	getFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	delFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error)
+	deletedKey string
+}
+
+func (m *mockEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+	return m.getFunc(ctx, key, opts...)
+}
+
+func (m *mockEtcdClient) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
+	if m.delFunc != nil {
+		return m.delFunc(ctx, key, opts...)
+	}
+	m.deletedKey = key
+	return &clientv3.DeleteResponse{Deleted: 1}, nil
+}
+
+func (m *mockEtcdClient) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Txn(ctx context.Context) clientv3.Txn { return nil }
+func (m *mockEtcdClient) Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error) {
+	return nil, nil
+}
+func (m *mockEtcdClient) Close() error { return nil }
+
+func newTestRegistry(client etcdClient) *EtcdRegistry {
+	return NewEtcdRegistry(client, &config.EtcdConfig{PathPrefix: "/skydns"}, "testhost", zerolog.Nop())
+}
+
+func TestParseEtcdValue(t *testing.T) {
+	er := newTestRegistry(nil) // parseEtcdValue does not touch the client
+
+	t.Run("valid A record reverses domain and strips index", func(t *testing.T) {
+		rec, err := er.parseEtcdValue(
+			"/skydns/com/example/app/x1",
+			`{"host":"10.0.0.1","record_type":"a","owner_hostname":"h1","owner_container_id":"abc","owner_container_name":"web","created":"2024-01-02T03:04:05Z","force":true}`,
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.Dns.Name != "app.example.com" {
+			t.Errorf("name = %q, want app.example.com", rec.Dns.Name)
+		}
+		if rec.Dns.Type != "A" {
+			t.Errorf("type = %q, want A (uppercased)", rec.Dns.Type)
+		}
+		if rec.Dns.Value != "10.0.0.1" {
+			t.Errorf("value = %q, want 10.0.0.1", rec.Dns.Value)
+		}
+		if rec.Meta.Hostname != "h1" || rec.Meta.ContainerID != "abc" || rec.Meta.ContainerName != "web" || !rec.Meta.Force {
+			t.Errorf("metadata not parsed correctly: %+v", rec.Meta)
+		}
+		if rec.Meta.Created.IsZero() {
+			t.Error("created timestamp not parsed")
+		}
+	})
+
+	t.Run("CNAME type", func(t *testing.T) {
+		rec, err := er.parseEtcdValue("/skydns/com/example/www/x1",
+			`{"host":"app.example.com","record_type":"CNAME","created":"2024-01-02T03:04:05Z"}`)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if rec.Dns.Type != "CNAME" || rec.Dns.Value != "app.example.com" {
+			t.Errorf("unexpected CNAME parse: %+v", rec.Dns)
+		}
+	})
+
+	errorCases := []struct {
+		name  string
+		key   string
+		value string
+	}{
+		{"missing record_type", "/skydns/com/example/app/x1", `{"host":"10.0.0.1","created":"2024-01-02T03:04:05Z"}`},
+		{"missing host", "/skydns/com/example/app/x1", `{"record_type":"A","created":"2024-01-02T03:04:05Z"}`},
+		{"bad created", "/skydns/com/example/app/x1", `{"host":"10.0.0.1","record_type":"A","created":"not-a-time"}`},
+		{"invalid json", "/skydns/com/example/app/x1", `{not json}`},
+	}
+	for _, tc := range errorCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := er.parseEtcdValue(tc.key, tc.value); err == nil {
+				t.Fatalf("%s: expected error, got nil", tc.name)
+			}
+		})
+	}
+}
+
+func TestList(t *testing.T) {
+	t.Run("parses valid records and skips invalid ones", func(t *testing.T) {
+		client := &mockEtcdClient{
+			getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+				return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+					{Key: []byte("/skydns/com/example/app/x1"), Value: []byte(`{"host":"10.0.0.1","record_type":"A","created":"2024-01-02T03:04:05Z"}`)},
+					{Key: []byte("/skydns/com/example/bad/x1"), Value: []byte(`{bad json}`)},
+				}}, nil
+			},
+		}
+		recs, err := newTestRegistry(client).List(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(recs) != 1 {
+			t.Fatalf("got %d records, want 1 (the invalid one should be skipped)", len(recs))
+		}
+		if recs[0].Dns.Name != "app.example.com" {
+			t.Errorf("name = %q, want app.example.com", recs[0].Dns.Name)
+		}
+	})
+
+	t.Run("propagates get error", func(t *testing.T) {
+		client := &mockEtcdClient{
+			getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+				return nil, context.DeadlineExceeded
+			},
+		}
+		if _, err := newTestRegistry(client).List(context.Background()); err == nil {
+			t.Fatal("expected error to propagate from client.Get")
+		}
+	})
+}
+
+func TestRemove(t *testing.T) {
+	client := &mockEtcdClient{
+		getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
+			return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
+				{Key: []byte("/skydns/com/example/app/x1"), Value: []byte(`{"host":"10.0.0.1","record_type":"A","owner_hostname":"h1","owner_container_name":"web","created":"2024-01-02T03:04:05Z"}`)},
+			}}, nil
+		},
+	}
+	rec := &dns.Record{
+		Dns:  dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"},
+		Meta: dns.RecordMetadata{Hostname: "h1", ContainerName: "web"},
+	}
+	if err := newTestRegistry(client).Remove(context.Background(), rec); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if client.deletedKey != "/skydns/com/example/app/x1" {
+		t.Errorf("deleted key = %q, want /skydns/com/example/app/x1", client.deletedKey)
+	}
+}

--- a/frontend/.prettierignore
+++ b/frontend/.prettierignore
@@ -1,0 +1,3 @@
+dist
+node_modules
+package-lock.json

--- a/frontend/.prettierrc.json
+++ b/frontend/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "printWidth": 100
+}

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -1,0 +1,30 @@
+import js from '@eslint/js';
+import tseslint from 'typescript-eslint';
+import reactHooks from 'eslint-plugin-react-hooks';
+import globals from 'globals';
+
+// Flat ESLint config (ESLint 9). Pragmatic baseline: TypeScript-aware linting
+// with the commonly-tripped rules set to "warn" so the pre-existing code does
+// not fail `make check`. Tighten these to "error" incrementally over time.
+export default tseslint.config(
+  { ignores: ['dist/**', 'node_modules/**'] },
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 2022,
+      sourceType: 'module',
+      globals: { ...globals.browser, ...globals.node },
+    },
+    plugins: { 'react-hooks': reactHooks },
+    rules: {
+      'react-hooks/rules-of-hooks': 'error',
+      'react-hooks/exhaustive-deps': 'warn',
+      '@typescript-eslint/no-explicit-any': 'warn',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-expressions': 'warn',
+      'no-unused-vars': 'off',
+    },
+  },
+);

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "auto-dns-webui",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "auto-dns-webui",
-      "version": "0.1.0",
+      "version": "0.5.0",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -30,7 +30,8 @@
         "sass-embedded": "^1.89.2",
         "typescript": "^5.8.3",
         "typescript-eslint": "^8.62.0",
-        "vite": "^6.3.5"
+        "vite": "^6.3.5",
+        "vitest": "^2.1.9"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -751,6 +752,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.4",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.4.tgz",
@@ -1440,6 +1448,92 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1641,6 +1735,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-function/-/async-function-1.0.0.tgz",
@@ -1691,6 +1795,16 @@
       "integrity": "sha512-7VPMEPuYznPSoR21NE1zvd2Xna6c/CloiZCfcMXR1Jny6PjX0N4Nsa38zcBFo/FMK+BlA+FLKbJCQ0i2yxp+Xg==",
       "dev": true,
       "license": "MIT/X11"
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/call-bind": {
       "version": "1.0.8",
@@ -1752,6 +1866,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1767,6 +1898,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/classnames": {
@@ -1901,6 +2042,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2090,6 +2241,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2425,6 +2583,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2433,6 +2601,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3393,6 +3571,13 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lucide-react": {
       "version": "0.515.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.515.0.tgz",
@@ -3400,6 +3585,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -3673,6 +3868,23 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -4484,6 +4696,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -4493,6 +4712,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -4668,6 +4901,20 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -4683,6 +4930,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4951,6 +5228,1102 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite-node/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vite-node/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5054,6 +6427,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -17,15 +17,19 @@
         "react-dom": "^19.1.0"
       },
       "devDependencies": {
+        "@eslint/js": "^9.39.4",
         "@types/node": "^22.14.1",
         "@types/react": "^19.1.7",
         "@types/react-dom": "^19.1.6",
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.5",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^5.2.0",
+        "globals": "^16.5.0",
         "prettier": "^3.5.3",
         "sass-embedded": "^1.89.2",
         "typescript": "^5.8.3",
+        "typescript-eslint": "^8.62.0",
         "vite": "^6.3.5"
       }
     },
@@ -515,9 +519,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-      "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -547,9 +551,9 @@
       }
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-      "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+      "version": "4.12.2",
+      "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+      "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -618,10 +622,23 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/@eslint/eslintrc/node_modules/globals": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1128,6 +1145,301 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.62.0.tgz",
+      "integrity": "sha512-o+mpz7EYiMzXoySXiKmzlabIvTVqUuK5yLrAedRPRDA0IpPFMUV1IXt6OqljIxX/kumN6EjUYp41Hqelh6p/Dw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/type-utils": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "ignore": "^7.0.5",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/parser": "^8.62.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.62.0.tgz",
+      "integrity": "sha512-dzHeT2gySzZtLDsuqxU9AkYgIsQoHAHtRBpOqM+Ofzx1Bwrd2RcCjQJ+6iQbsHOIR6NS33bF2W1k3blN1zLDrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.62.0.tgz",
+      "integrity": "sha512-wexnCqiTg7BOGtbLDftYpRWlmLq4xfoMd7BKFR6Y75sZS3QmRKLdN3yWLhmIYgqMmP/OXWpj3H8odkb5nGURCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.62.0",
+        "@typescript-eslint/types": "^8.62.0",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.62.0.tgz",
+      "integrity": "sha512-1lX38kNxXIRb8mEc3lbq5mdHq1Pf2+U0nFU65KfT18mtPxxl0fvjuEE92mHuXPuCtElJhOrddOpyMlM3Z0umEA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.62.0.tgz",
+      "integrity": "sha512-y2GAdB6ykaXUvuspbYnizQc4oDDz0Tz/Yc7iWrXf9mx8vm/L/0vLHCe0tS2boG96Zy+DivnVDQ9ZUEWoHqqx1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.62.0.tgz",
+      "integrity": "sha512-+g5O3j0w2ldzC86Pv6fvbO/xhAonbJFIdf/MKQ1d30gndlsVzUOE83ldfSE15Qrl9fhFjK6AovHs5Wpp6vx86w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.62.0.tgz",
+      "integrity": "sha512-KvAclkktORPvM54TgLgA4z9HIV1M8zOgw9ZVNXl9f/8dLYfXYX1wkMXP7qmabpijQRV5bHJLOmoyGQbLMaUYeg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.62.0.tgz",
+      "integrity": "sha512-+hVbNxtW64pIcZWDPGbyaKF7vp2IBTVY5ma1blwwksrjdsbdqqEKvJWMGbBofei4F6Dovx1M0RJgoFeNu2279A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.62.0",
+        "@typescript-eslint/tsconfig-utils": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/visitor-keys": "8.62.0",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.62.0.tgz",
+      "integrity": "sha512-82r66fi9zYwZ+mTq3vKgwjbZ1PVk/DJzrXFLpG6RnBbdvH8TEGVHIs9H4d2drhkOzf0syZuD/OZvvlu6GDbP4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.62.0",
+        "@typescript-eslint/types": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.62.0.tgz",
+      "integrity": "sha512-CY3uyFSRbcQv3nnSv8S0+lDftMVz6P963PoRlxrV7ew/Md564g9ut60PYzdLM5qW4jFn93GBF+Soi90ISAN+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.62.0",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -1574,9 +1886,9 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2003,6 +2315,19 @@
         "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7"
       }
     },
+    "node_modules/eslint-plugin-react-hooks": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -2031,6 +2356,19 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint/node_modules/@eslint/js": {
+      "version": "9.28.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {
@@ -2119,11 +2457,14 @@
       "license": "MIT"
     },
     "node_modules/fdir": {
-      "version": "6.4.6",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.4.6.tgz",
-      "integrity": "sha512-hiFoqpyZcfNm1yc4u8oWCf9A2c4D3QjCrks3zmoVKVxpQRzmPNar1hUJcBG2RQHvEVGDN+Jm81ZheVLAQMK6+w==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2327,9 +2668,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+      "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4328,20 +4669,33 @@
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.14.tgz",
-      "integrity": "sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "fdir": "^6.4.4",
-        "picomatch": "^4.0.2"
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
@@ -4453,6 +4807,30 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.62.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.62.0.tgz",
+      "integrity": "sha512-8QxXi+ZACKX0kaqO4gY8kn0RSD9gFfaHDWwjqtEN48aWCBkX4MJaufWN+c3BzlrXLOxfywDL8CaoqUwcRq4j4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.62.0",
+        "@typescript-eslint/parser": "8.62.0",
+        "@typescript-eslint/typescript-estree": "8.62.0",
+        "@typescript-eslint/utils": "8.62.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-dns-webui",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "typecheck": "tsc --noEmit",
@@ -25,7 +27,8 @@
     "sass-embedded": "^1.89.2",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.62.0",
-    "vite": "^6.3.5"
+    "vite": "^6.3.5",
+    "vitest": "^2.1.9"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,20 +1,30 @@
 {
   "name": "auto-dns-webui",
   "version": "0.1.0",
+  "type": "module",
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "typecheck": "tsc --noEmit",
+    "format": "prettier --write \"src/**/*.{ts,tsx,scss,css}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,scss,css}\""
   },
   "devDependencies": {
+    "@eslint/js": "^9.39.4",
     "@types/node": "^22.14.1",
     "@types/react": "^19.1.7",
     "@types/react-dom": "^19.1.6",
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.5",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^5.2.0",
+    "globals": "^16.5.0",
     "prettier": "^3.5.3",
     "sass-embedded": "^1.89.2",
     "typescript": "^5.8.3",
+    "typescript-eslint": "^8.62.0",
     "vite": "^6.3.5"
   },
   "dependencies": {

--- a/frontend/src/utils/filters.test.ts
+++ b/frontend/src/utils/filters.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { Filters, RecordEntry } from '../types';
+import { deriveFilterOptions, filterRecords, getFacetCounts } from './filters';
+import { enrichSearchable } from './record';
+
+function rec(
+  name: string,
+  type: string,
+  value: string,
+  hostname: string,
+  force = false,
+): RecordEntry {
+  return {
+    dnsRecord: { name, type, value },
+    metadata: { containerId: 'id-' + name, containerName: name, created: '2024-01-01T00:00:00Z', hostname, force },
+  };
+}
+
+const sample: RecordEntry[] = [
+  rec('app.example.com', 'A', '10.0.0.1', 'alpha', true),
+  rec('db.example.com', 'AAAA', 'fd00::1', 'beta', false),
+  rec('www.example.com', 'CNAME', 'app.example.com', 'alpha', false),
+];
+
+const emptyFilters = (): Filters => ({
+  name: '',
+  type: [],
+  value: [],
+  containerId: '',
+  containerName: '',
+  hostname: [],
+  force: [],
+});
+
+describe('deriveFilterOptions', () => {
+  it('returns unique, sorted option lists', () => {
+    const opts = deriveFilterOptions(sample);
+    expect(opts.recordTypes).toEqual(['A', 'AAAA', 'CNAME']);
+    expect(opts.hostnames).toEqual(['alpha', 'beta']);
+    expect(opts.forceValues).toEqual([true, false]); // booleans sorted true-first
+  });
+});
+
+describe('filterRecords', () => {
+  const enriched = enrichSearchable(sample);
+
+  it('returns all when no filters or search', () => {
+    expect(filterRecords(enriched, emptyFilters(), '')).toHaveLength(3);
+  });
+
+  it('filters by type', () => {
+    const f = { ...emptyFilters(), type: ['A'] };
+    const out = filterRecords(enriched, f, '');
+    expect(out.map((r) => r.dnsRecord.name)).toEqual(['app.example.com']);
+  });
+
+  it('filters by hostname (multi-select)', () => {
+    const f = { ...emptyFilters(), hostname: ['alpha'] };
+    expect(filterRecords(enriched, f, '')).toHaveLength(2);
+  });
+
+  it('filters by force', () => {
+    const f = { ...emptyFilters(), force: [true] };
+    expect(filterRecords(enriched, f, '')).toHaveLength(1);
+  });
+
+  it('applies free-text search across fields (case-insensitive)', () => {
+    expect(filterRecords(enriched, emptyFilters(), 'BETA')).toHaveLength(1);
+    expect(filterRecords(enriched, emptyFilters(), 'fd00')).toHaveLength(1);
+  });
+
+  it('combines filters with AND semantics', () => {
+    const f = { ...emptyFilters(), hostname: ['alpha'], type: ['CNAME'] };
+    expect(filterRecords(enriched, f, '').map((r) => r.dnsRecord.name)).toEqual(['www.example.com']);
+  });
+});
+
+describe('getFacetCounts', () => {
+  it('counts records per facet value', () => {
+    const counts = getFacetCounts(sample, emptyFilters());
+    expect(counts.type).toEqual({ A: 1, AAAA: 1, CNAME: 1 });
+    expect(counts.hostname).toEqual({ alpha: 2, beta: 1 });
+    expect(counts.force).toEqual({ true: 1, false: 2 });
+  });
+});

--- a/frontend/src/utils/object.test.ts
+++ b/frontend/src/utils/object.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { getValueByPath } from './object';
+
+describe('getValueByPath', () => {
+  const obj = { dnsRecord: { name: 'app.example.com' }, metadata: { force: true } };
+
+  it('reads a nested value by dotted path', () => {
+    expect(getValueByPath(obj, 'dnsRecord.name')).toBe('app.example.com');
+    expect(getValueByPath(obj, 'metadata.force')).toBe(true);
+  });
+
+  it('returns undefined for a missing path instead of throwing', () => {
+    expect(getValueByPath(obj, 'metadata.missing')).toBeUndefined();
+    expect(getValueByPath(obj, 'nope.deeper.still')).toBeUndefined();
+  });
+});

--- a/frontend/src/utils/record.test.ts
+++ b/frontend/src/utils/record.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { RecordEntry } from '../types';
+import { getRecordKey, enrichSearchable } from './record';
+
+function makeRecord(overrides: Partial<RecordEntry['dnsRecord']> = {}): RecordEntry {
+  return {
+    dnsRecord: { name: 'app.example.com', type: 'A', value: '10.0.0.1', ...overrides },
+    metadata: {
+      containerId: 'abc123',
+      containerName: 'web',
+      created: '2024-01-02T03:04:05Z',
+      hostname: 'alpha',
+      force: true,
+    },
+  };
+}
+
+describe('getRecordKey', () => {
+  it('joins name, type, value, and container id', () => {
+    expect(getRecordKey(makeRecord())).toBe('app.example.com|A|10.0.0.1|abc123');
+  });
+
+  it('distinguishes records that differ only by type', () => {
+    expect(getRecordKey(makeRecord({ type: 'A' }))).not.toBe(getRecordKey(makeRecord({ type: 'AAAA' })));
+  });
+});
+
+describe('enrichSearchable', () => {
+  it('adds a lowercased searchable string covering all fields', () => {
+    const [r] = enrichSearchable([makeRecord()]);
+    expect(r.searchable).toContain('app.example.com');
+    expect(r.searchable).toContain('alpha');
+    expect(r.searchable).toContain('web');
+    expect(r.searchable).toContain('true');
+    expect(r.searchable).toBe(r.searchable.toLowerCase());
+  });
+
+  it('preserves the original record fields', () => {
+    const [r] = enrichSearchable([makeRecord()]);
+    expect(r.dnsRecord.name).toBe('app.example.com');
+    expect(r.metadata.hostname).toBe('alpha');
+  });
+});

--- a/frontend/src/utils/sort.test.ts
+++ b/frontend/src/utils/sort.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { RecordEntry, SortState } from '../types';
+import { sortRecords, SORT_KEYS } from './sort';
+
+function rec(name: string, type = 'A', hostname = 'alpha'): RecordEntry {
+  return {
+    dnsRecord: { name, type, value: '10.0.0.1' },
+    metadata: { containerId: 'id', containerName: 'c', created: '2024-01-01T00:00:00Z', hostname, force: false },
+  };
+}
+
+const names = (rs: RecordEntry[]) => rs.map((r) => r.dnsRecord.name);
+
+describe('SORT_KEYS', () => {
+  it('exposes the expected sortable keys', () => {
+    expect(SORT_KEYS).toContain('dnsRecord.name');
+    expect(SORT_KEYS).toContain('metadata.created');
+    expect(SORT_KEYS).toContain('metadata.hostname');
+  });
+});
+
+describe('sortRecords', () => {
+  it('sorts ascending by a single key', () => {
+    const sort: SortState = [{ key: 'dnsRecord.name', ascending: true }];
+    expect(names(sortRecords([rec('c'), rec('a'), rec('b')], sort))).toEqual(['a', 'b', 'c']);
+  });
+
+  it('sorts descending by a single key', () => {
+    const sort: SortState = [{ key: 'dnsRecord.name', ascending: false }];
+    expect(names(sortRecords([rec('a'), rec('c'), rec('b')], sort))).toEqual(['c', 'b', 'a']);
+  });
+
+  it('applies secondary sort keys and falls back to name as tiebreaker', () => {
+    const sort: SortState = [{ key: 'metadata.hostname', ascending: true }];
+    const input = [rec('z', 'A', 'beta'), rec('a', 'A', 'alpha'), rec('b', 'A', 'alpha')];
+    // alpha group first (a, b by name tiebreak), then beta (z)
+    expect(names(sortRecords(input, sort))).toEqual(['a', 'b', 'z']);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [rec('b'), rec('a')];
+    sortRecords(input, [{ key: 'dnsRecord.name', ascending: true }]);
+    expect(names(input)).toEqual(['b', 'a']);
+  });
+});

--- a/frontend/src/utils/url.test.ts
+++ b/frontend/src/utils/url.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+import { Filters, SortState } from '../types';
+import { serializeToUrl, parseFromUrl } from './url';
+
+const emptyFilters = (): Filters => ({
+  name: '',
+  type: [],
+  value: [],
+  containerId: '',
+  containerName: '',
+  hostname: [],
+  force: [],
+});
+
+const DEFAULT_SORT: SortState = [{ key: 'dnsRecord.name', ascending: true }];
+
+describe('serializeToUrl', () => {
+  it('omits the default sort and empty filters', () => {
+    expect(serializeToUrl('', emptyFilters(), DEFAULT_SORT)).toBe('');
+  });
+
+  it('serializes search and filters with friendly keys', () => {
+    const f = { ...emptyFilters(), type: ['A', 'CNAME'], hostname: ['alpha'] };
+    const qs = new URLSearchParams(serializeToUrl('myquery', f, DEFAULT_SORT));
+    expect(qs.get('q')).toBe('myquery');
+    expect(qs.get('type')).toBe('A,CNAME');
+    expect(qs.get('hostname')).toBe('alpha');
+  });
+
+  it('includes a non-default sort using friendly names', () => {
+    const sort: SortState = [{ key: 'metadata.created', ascending: false }];
+    const qs = new URLSearchParams(serializeToUrl('', emptyFilters(), sort));
+    expect(qs.get('sort')).toBe('created:desc');
+  });
+});
+
+describe('parseFromUrl', () => {
+  it('round-trips search, filters, and sort', () => {
+    const f = { ...emptyFilters(), name: 'app', type: ['A'], force: [true] };
+    const sort: SortState = [{ key: 'metadata.hostname', ascending: false }];
+    const serialized = serializeToUrl('q1', f, sort);
+
+    const parsed = parseFromUrl(new URLSearchParams(serialized));
+    expect(parsed.search).toBe('q1');
+    expect(parsed.filters.name).toBe('app');
+    expect(parsed.filters.type).toEqual(['A']);
+    expect(parsed.filters.force).toEqual([true]);
+    expect(parsed.sort).toEqual(sort);
+  });
+
+  it('returns the default sort when the sort param is absent', () => {
+    expect(parseFromUrl(new URLSearchParams('')).sort).toEqual(DEFAULT_SORT);
+  });
+
+  it('falls back to the default sort on an invalid sort key', () => {
+    expect(parseFromUrl(new URLSearchParams('sort=bogus:asc')).sort).toEqual(DEFAULT_SORT);
+  });
+});

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -2,7 +2,8 @@
     "compilerOptions": {
         "target": "esnext",
         "module": "esnext",
-        "moduleResolution": "node",
+        "moduleResolution": "bundler",
+        "skipLibCheck": true,
         "typeRoots": [
             "./src/types",
             "./node_modules/@types"

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['src/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Release v0.5.0

Integrates the **Foundations** and **Tests** milestones into `main`. This brings the repo from "no tests, no PR CI, ad-hoc versioning" to a documented SDLC with green quality gates.

### What's in it
**Foundations**
- `CONTRIBUTING.md`, PR/issue templates, label scheme (#10)
- Makefile + npm quality targets: `check`/`lint`/`vet`/`typecheck`/`format`/`test` (#11)
- CI workflow: backend (build/vet/golangci-lint/race tests) + frontend (lint/typecheck/build) on PRs and pushes (#12)
- CHANGELOG/version reconcile + documented dependency-aware SemVer policy (#13)
- `CLAUDE.md` / `AGENTS.md` (#14)
- Dependabot + `govulncheck`/`npm audit` security workflow (#17)

**Tests**
- Backend unit tests — config, registry (`parseEtcdValue`/`List`/`Remove`), API handler, MCP tools (#15)
- Frontend Vitest unit tests for `utils/` + `TESTS.md` (#16)

**Incidental fixes surfaced by the new gates**
- Go toolchain `1.26.3 → 1.26.4` (remediates two called stdlib vulns: `GO-2026-5039`, `GO-2026-5037`)
- `golangci-lint-action` v6 → v8 (pinned `v2.12.2`); resolved the `errcheck` findings (incl. the `/api/records` encode error, part of #20)

### Release mechanics
- CHANGELOG `## [Unreleased]` has been renamed to `## [0.5.0] - 2026-06-25` (verified the `docker.yaml` awk extracts it correctly), with a fresh empty `## [Unreleased]` seeded.
- **After you merge this to `main`**, tag `v0.5.0` to trigger `.github/workflows/docker.yaml` (multi-arch GHCR image + GitHub Release from the `[0.5.0]` notes).

Closes #10
Closes #11
Closes #12
Closes #13
Closes #14
Closes #15
Closes #16
Closes #17

> I have **not** merged or tagged anything — this PR is yours to review and merge, and the tag is yours to push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NyxQ5Fi3vmBQ5odhqPREmo)_