### PR TITLE
chore(ci): ignore eslint/@eslint/js major bumps until plugin supports v10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -37,6 +37,15 @@ updates:
         update-types:
           - minor
           - patch
+    ignore:
+      # ESLint 10 is blocked upstream: eslint-plugin-react (latest 7.37.5)
+      # only declares peer support up to eslint ^9.7, so `npm ci`/lint cannot
+      # resolve with eslint 10. Hold the major bumps until the plugin ships
+      # eslint-10 support, then drop these ignores. Minor/patch still flow.
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@eslint/js"
+        update-types: ["version-update:semver-major"]
 
   # GitHub Actions used by the workflows
   - package-ecosystem: github-actions


### PR DESCRIPTION
ESLint 10 can't currently be installed in this project: `eslint-plugin-react` (latest `7.37.5`, and even its `next` tag `7.8.0-rc.0`) declares peer support only up to `eslint ^9.7`. With eslint 10, `npm ci` fails peer resolution and the lint gate can't run.

This adds a Dependabot `ignore` for **major** bumps of `eslint` and `@eslint/js` in `/frontend`, so Dependabot stops opening unmergeable PRs (#51, #54). Minor/patch eslint updates still flow normally.

**Revert when ready:** drop the two `ignore` entries once `eslint-plugin-react` ships an eslint-10-compatible release.

Closes #51
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0199CHbmbox9QacoRvB2RNd4)_