### PR TITLE
Release v0.6.0 — correctness milestone

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -54,6 +54,8 @@ jobs:
         uses: docker/build-push-action@v7
         with:
           context: .
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
           platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
           provenance: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,34 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Frontend: loading and error states for the record list. A failed `/api/records`
+  fetch now shows an error message with a **Retry** button instead of leaving a
+  permanently blank page, and a loading indicator is shown while fetching (#20).
+
+### Changed
+- MCP server now reports the application version instead of a hardcoded `1.0.0`.
+  The version is stamped into the binary at build time via
+  `-ldflags "-X .../internal/version.Version=<v>"` (defaulting to `dev` for
+  unstamped/local builds); release images are stamped from the git tag through
+  the Dockerfile `VERSION` build arg (#20).
+
+### Removed
+- Dead write-path scaffolding carried over from `docker-coredns-sync`: the unused
+  `Registry.Remove` and `Registry.LockTransaction` methods and the previously
+  **required** etcd lock configuration (`etcd.lock_ttl`, `etcd.lock_timeout`,
+  `etcd.lock_retry_interval`, with their CLI flags). They were only exercised by
+  the locking path, which this read-only app never invokes; operators no longer
+  need to set these meaningless values to start. Reintroduce locking alongside a
+  write/delete feature if one is ever added (#19).
+
+### Fixed
+- Dev-mode Vite reverse proxy now honors the configured `server.proxy.hostname`
+  and `server.proxy.port` instead of a hardcoded `http://localhost:5173`, and
+  `ProxyToVite` returns an error rather than calling `log.Fatalf` (#18).
+- Corrected the `dns.DnsRecord.Type` doc comment to note `AAAA` is supported, not
+  just `A`/`CNAME` (#20).
+
 ## [0.5.1] - 2026-06-26
 
 Maintenance release: dependency and CI updates plus Dependabot automation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-26
+
 ### Added
 - Frontend: loading and error states for the record list. A failed `/api/records`
   fetch now shows an error message with a **Retry** button instead of leaving a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,9 @@ etcdctl --endpoints http://etcd:2379 get --prefix /skydns
    segment and **reversing** the remaining domain labels, then unmarshals the
    JSON value (`host`, `record_type`, `owner_hostname`, `owner_container_id`,
    `owner_container_name`, `created`, `force`) into a `dns.Record`. `List` is the
-   only method the app actually calls. (`Remove`/`LockTransaction` exist but are
-   currently unused — see the open tech-debt issue.)
+   only registry method (this is a read-only app); the unused `Remove`/
+   `LockTransaction` write-path scaffolding and its required lock config were
+   removed. Reintroduce locking alongside a delete feature if/when that lands.
 5. **`backend/internal/api/handlers.go`** — `Records` calls `Registry.List` and
    writes the records as JSON to `GET /api/records`.
 6. **`backend/internal/server/server.go`** — Registers `/api/records` and mounts

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,12 @@ RUN go mod download
 COPY backend/ .
 # Copy built frontend into the Go backend directory to be embedded
 COPY --from=frontend-builder /frontend/dist ./internal/frontend/dist
+# Version stamped into the binary (defaults to "dev"; release builds pass the tag)
+ARG VERSION=dev
 # Build the Go binary with embedded frontend
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o auto-dns-webui ./cmd/auto-dns-webui
+RUN CGO_ENABLED=0 GOOS=linux go build \
+    -ldflags="-s -w -X github.com/auto-dns/auto-dns-webui/internal/version.Version=${VERSION}" \
+    -o auto-dns-webui ./cmd/auto-dns-webui
 
 # ===== Stage 3: Dev Container =====
 FROM mcr.microsoft.com/devcontainers/go:1.26 AS dev

--- a/backend/cmd/auto-dns-webui/root.go
+++ b/backend/cmd/auto-dns-webui/root.go
@@ -85,15 +85,6 @@ func init() {
 	rootCmd.PersistentFlags().String("etcd.path-prefix", "", "etcd key path prefix (e.g., /skydns)")
 	_ = viper.BindPFlag("etcd.path_prefix", rootCmd.PersistentFlags().Lookup("etcd.path-prefix"))
 
-	rootCmd.PersistentFlags().Float64("etcd.lock_ttl", 0, "etcd lock ttl")
-	_ = viper.BindPFlag("etcd.lock_ttl", rootCmd.PersistentFlags().Lookup("etcd.lock_ttl"))
-
-	rootCmd.PersistentFlags().Float64("etcd.lock_timeout", 0, "etcd lock timeout")
-	_ = viper.BindPFlag("etcd.lock_timeout", rootCmd.PersistentFlags().Lookup("etcd.lock_timeout"))
-
-	rootCmd.PersistentFlags().Float64("etcd.lock_retry_interval", 0, "etcd lock retry interval")
-	_ = viper.BindPFlag("etcd.lock_retry_interval", rootCmd.PersistentFlags().Lookup("etcd.lock_retry_interval"))
-
 	// Log Flags
 	rootCmd.PersistentFlags().String("log.level", "", "Log level (e.g., TRACE, DEBUG, INFO, WARN, ERROR, FATAL)")
 	_ = viper.BindPFlag("log.level", rootCmd.PersistentFlags().Lookup("log.level"))

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -21,11 +21,7 @@ type mockRegistry struct {
 }
 
 func (m *mockRegistry) List(ctx context.Context) ([]*dns.Record, error) { return m.records, m.err }
-func (m *mockRegistry) Remove(ctx context.Context, record *dns.Record) error { return nil }
-func (m *mockRegistry) LockTransaction(ctx context.Context, key []string, fn func() error) error {
-	return fn()
-}
-func (m *mockRegistry) Close() error { return nil }
+func (m *mockRegistry) Close() error                                    { return nil }
 
 func TestRecords_Success(t *testing.T) {
 	reg := &mockRegistry{records: []*dns.Record{

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -29,7 +29,7 @@ func NewRegistry(cfg *config.Config, logger zerolog.Logger) (registry.Registry, 
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to etcd: %w", err)
 	}
-	reg := registry.NewEtcdRegistry(etcdClient, &cfg.Etcd, cfg.App.Hostname, logger)
+	reg := registry.NewEtcdRegistry(etcdClient, &cfg.Etcd, logger)
 	return reg, nil
 }
 
@@ -37,7 +37,7 @@ func NewHandler(r registry.Registry, logger zerolog.Logger) api.HandlerInterface
 	return api.NewHandler(r, logger)
 }
 
-func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, logger zerolog.Logger) httpServer {
+func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, logger zerolog.Logger) (httpServer, error) {
 	mux := http.NewServeMux()
 
 	http := &http.Server{
@@ -57,7 +57,10 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 
 	handler := NewHandler(reg, logger)
 
-	srv := NewServer(&cfg.Server, handler, logger)
+	srv, err := NewServer(&cfg.Server, handler, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create server: %w", err)
+	}
 
 	var mcpHTTP *http.Server
 	if cfg.MCP.Enabled {

--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -22,12 +22,9 @@ type AppConfig struct {
 }
 
 type EtcdConfig struct {
-	Host              string  `mapstructure:"host"`
-	Port              int     `mapstructure:"port"`
-	PathPrefix        string  `mapstructure:"path_prefix"`
-	LockTTL           float64 `mapstructure:"lock_ttl"`
-	LockTimeout       float64 `mapstructure:"lock_timeout"`
-	LockRetryInterval float64 `mapstructure:"lock_retry_interval"`
+	Host       string `mapstructure:"host"`
+	Port       int    `mapstructure:"port"`
+	PathPrefix string `mapstructure:"path_prefix"`
 }
 
 type LoggingConfig struct {
@@ -95,9 +92,6 @@ func initConfig() error {
 	viper.SetDefault("etcd.host", "localhost")
 	viper.SetDefault("etcd.port", 2379)
 	viper.SetDefault("etcd.path_prefix", "/skydns")
-	viper.SetDefault("etcd.lock_ttl", 5.0)
-	viper.SetDefault("etcd.lock_timeout", 2.0)
-	viper.SetDefault("etcd.lock_retry_interval", 0.1)
 	viper.SetDefault("log.level", "INFO")
 	viper.SetDefault("mcp.enabled", false)
 	viper.SetDefault("mcp.port", 0)
@@ -129,15 +123,6 @@ func (c *Config) validate() error {
 	}
 	if c.Etcd.PathPrefix == "" {
 		return fmt.Errorf("etcd.path_prefix cannot be empty")
-	}
-	if c.Etcd.LockTTL <= 0 {
-		return fmt.Errorf("etcd.lock_ttl must be > 0")
-	}
-	if c.Etcd.LockTimeout <= 0 {
-		return fmt.Errorf("etcd.lock_timeout must be > 0")
-	}
-	if c.Etcd.LockRetryInterval <= 0 {
-		return fmt.Errorf("etcd.lock_retry_interval must be > 0")
 	}
 	validLevels := map[string]struct{}{
 		"TRACE": {}, "DEBUG": {}, "INFO": {}, "WARN": {}, "ERROR": {}, "FATAL": {},

--- a/backend/internal/config/config_test.go
+++ b/backend/internal/config/config_test.go
@@ -7,7 +7,7 @@ import "testing"
 func validConfig() Config {
 	return Config{
 		App:  AppConfig{Hostname: "dns1"},
-		Etcd: EtcdConfig{Host: "localhost", Port: 2379, PathPrefix: "/skydns", LockTTL: 5, LockTimeout: 2, LockRetryInterval: 0.1},
+		Etcd: EtcdConfig{Host: "localhost", Port: 2379, PathPrefix: "/skydns"},
 		Log:  LoggingConfig{Level: "INFO"},
 		MCP:  MCPConfig{Enabled: false, Port: 0},
 		Server: ServerConfig{
@@ -56,9 +56,6 @@ func TestValidate_Errors(t *testing.T) {
 		{"etcd port zero", func(c *Config) { c.Etcd.Port = 0 }},
 		{"etcd port too high", func(c *Config) { c.Etcd.Port = 70000 }},
 		{"empty path prefix", func(c *Config) { c.Etcd.PathPrefix = "" }},
-		{"lock ttl zero", func(c *Config) { c.Etcd.LockTTL = 0 }},
-		{"lock timeout zero", func(c *Config) { c.Etcd.LockTimeout = 0 }},
-		{"lock retry interval zero", func(c *Config) { c.Etcd.LockRetryInterval = 0 }},
 		{"invalid log level", func(c *Config) { c.Log.Level = "VERBOSE" }},
 		{"empty proxy hostname", func(c *Config) { c.Server.Proxy.Hostname = "" }},
 		{"proxy port zero", func(c *Config) { c.Server.Proxy.Port = 0 }},

--- a/backend/internal/dns/record.go
+++ b/backend/internal/dns/record.go
@@ -9,7 +9,7 @@ type Record struct {
 
 type DnsRecord struct {
 	Name  string `json:"name"`
-	Type  string `json:"type"`  // A or CNAME
+	Type  string `json:"type"`  // A, AAAA, or CNAME
 	Value string `json:"value"` // IP or hostname
 }
 

--- a/backend/internal/frontend/proxy.go
+++ b/backend/internal/frontend/proxy.go
@@ -1,16 +1,18 @@
 package frontend
 
 import (
-	"log"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 )
 
-func ProxyToVite() http.Handler {
-	target, err := url.Parse("http://localhost:5173")
+// ProxyToVite returns a reverse proxy to the Vite dev server at the given
+// hostname and port (dev mode only).
+func ProxyToVite(hostname string, port int) (http.Handler, error) {
+	target, err := url.Parse(fmt.Sprintf("http://%s:%d", hostname, port))
 	if err != nil {
-		log.Fatalf("Invalid Vite dev server URL: %v", err)
+		return nil, fmt.Errorf("invalid Vite dev server URL: %w", err)
 	}
-	return httputil.NewSingleHostReverseProxy(target)
+	return httputil.NewSingleHostReverseProxy(target), nil
 }

--- a/backend/internal/frontend/proxy_test.go
+++ b/backend/internal/frontend/proxy_test.go
@@ -40,7 +40,7 @@ func TestProxyToVite_HonorsConfiguredTarget(t *testing.T) {
 	if err != nil {
 		t.Fatalf("request through proxy failed: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("status = %d, want 200 — proxy did not reach the configured target", resp.StatusCode)

--- a/backend/internal/frontend/proxy_test.go
+++ b/backend/internal/frontend/proxy_test.go
@@ -1,0 +1,51 @@
+package frontend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"testing"
+)
+
+// TestProxyToVite_HonorsConfiguredTarget verifies the proxy forwards to the
+// configured hostname/port rather than a hardcoded one (regression test for the
+// dev proxy ignoring server.proxy.hostname / server.proxy.port).
+func TestProxyToVite_HonorsConfiguredTarget(t *testing.T) {
+	var gotPath string
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer upstream.Close()
+
+	u, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parsing upstream URL: %v", err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatalf("parsing upstream port: %v", err)
+	}
+
+	proxy, err := ProxyToVite(u.Hostname(), port)
+	if err != nil {
+		t.Fatalf("ProxyToVite returned error: %v", err)
+	}
+
+	front := httptest.NewServer(proxy)
+	defer front.Close()
+
+	resp, err := http.Get(front.URL + "/index.html")
+	if err != nil {
+		t.Fatalf("request through proxy failed: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("status = %d, want 200 — proxy did not reach the configured target", resp.StatusCode)
+	}
+	if gotPath != "/index.html" {
+		t.Errorf("upstream path = %q, want /index.html", gotPath)
+	}
+}

--- a/backend/internal/mcp/handler.go
+++ b/backend/internal/mcp/handler.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/auto-dns/auto-dns-webui/internal/dns"
+	"github.com/auto-dns/auto-dns-webui/internal/version"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/rs/zerolog"
 )
@@ -19,7 +20,7 @@ type Deps struct {
 }
 
 func NewHandler(d Deps) http.Handler {
-	s := server.NewMCPServer("auto-dns-webui", "1.0.0")
+	s := server.NewMCPServer("auto-dns-webui", version.Version)
 	registerTools(s, d)
 	return server.NewStreamableHTTPServer(s, server.WithStateLess(true))
 }

--- a/backend/internal/registry/etcd_registry.go
+++ b/backend/internal/registry/etcd_registry.go
@@ -14,29 +14,23 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// etcdClient is the subset of clientv3.Client this read-only app needs.
 type etcdClient interface {
 	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
-	Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error)
-	Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error)
-	Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error)
-	Txn(ctx context.Context) clientv3.Txn
-	Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error)
 	Close() error
 }
 
 type EtcdRegistry struct {
-	client   etcdClient
-	cfg      *config.EtcdConfig
-	hostname string
-	logger   zerolog.Logger
+	client etcdClient
+	cfg    *config.EtcdConfig
+	logger zerolog.Logger
 }
 
-func NewEtcdRegistry(client etcdClient, cfg *config.EtcdConfig, hostname string, logger zerolog.Logger) *EtcdRegistry {
+func NewEtcdRegistry(client etcdClient, cfg *config.EtcdConfig, logger zerolog.Logger) *EtcdRegistry {
 	return &EtcdRegistry{
-		client:   client,
-		cfg:      cfg,
-		hostname: hostname,
-		logger:   logger,
+		client: client,
+		cfg:    cfg,
+		logger: logger,
 	}
 }
 
@@ -97,44 +91,6 @@ func (er *EtcdRegistry) parseEtcdValue(key, value string) (*dns.Record, error) {
 	return rec, nil
 }
 
-// Remove finds and deletes the etcd key that matches the record.
-func (er *EtcdRegistry) Remove(ctx context.Context, record *dns.Record) error {
-	fqdn := record.Dns.Name
-	trimmed := strings.Trim(fqdn, ".")
-	parts := strings.Split(trimmed, ".")
-	// Reverse parts.
-	for i, j := 0, len(parts)-1; i < j; i, j = i+1, j-1 {
-		parts[i], parts[j] = parts[j], parts[i]
-	}
-	baseKey := fmt.Sprintf("%s/%s", er.cfg.PathPrefix, strings.Join(parts, "/"))
-	resp, err := er.client.Get(ctx, baseKey, clientv3.WithPrefix())
-	if err != nil {
-		return err
-	}
-	for _, kv := range resp.Kvs {
-		keyStr := string(kv.Key)
-		var data map[string]interface{}
-		if err := json.Unmarshal(kv.Value, &data); err != nil {
-			er.logger.Warn().Err(err).Msgf("Could not parse key %s", keyStr)
-			continue
-		}
-		// Match based on record fields.
-		if data["host"] == record.Dns.Value &&
-			data["record_type"] == record.Dns.Type &&
-			data["owner_hostname"] == record.Meta.Hostname &&
-			data["owner_container_name"] == record.Meta.ContainerName {
-			_, err := er.client.Delete(ctx, keyStr)
-			if err != nil {
-				er.logger.Warn().Err(err).Msgf("Failed to delete key %s", keyStr)
-				return err
-			}
-			er.logger.Info().Msgf("Deleted key %s", keyStr)
-			return nil
-		}
-	}
-	return nil
-}
-
 // List retrieves all records stored in etcd under the configured prefix.
 func (er *EtcdRegistry) List(ctx context.Context) ([]*dns.Record, error) {
 	prefix := er.cfg.PathPrefix
@@ -153,66 +109,6 @@ func (er *EtcdRegistry) List(ctx context.Context) ([]*dns.Record, error) {
 		records = append(records, record)
 	}
 	return records, nil
-}
-
-// LockTransaction provides a distributed lock using etcd transactions.
-// It takes keys (as a slice of string), tries to acquire locks on all of them,
-// runs the function, and finally releases all locks.
-func (er *EtcdRegistry) LockTransaction(ctx context.Context, keys []string, fn func() error) error {
-	// Ensure unique sorted keys.
-	uniqueKeys := keys
-	leases := make([]struct {
-		lockKey string
-		lease   clientv3.LeaseID
-	}, 0)
-
-	for _, key := range uniqueKeys {
-		lockKey := fmt.Sprintf("/locks/%s", key)
-		leaseResp, err := er.client.Grant(ctx, int64(er.cfg.LockTTL))
-		if err != nil {
-			return fmt.Errorf("failed to create lease: %w", err)
-		}
-		acquired := false
-		start := time.Now()
-		for time.Since(start) < time.Duration(er.cfg.LockTimeout)*time.Second {
-			txnResp, err := er.client.Txn(ctx).
-				If(clientv3.Compare(clientv3.CreateRevision(lockKey), "=", 0)).
-				Then(clientv3.OpPut(lockKey, er.hostname, clientv3.WithLease(leaseResp.ID))).
-				Commit()
-			if err != nil {
-				return err
-			}
-			if txnResp.Succeeded {
-				acquired = true
-				leases = append(leases, struct {
-					lockKey string
-					lease   clientv3.LeaseID
-				}{lockKey, leaseResp.ID})
-				break
-			}
-			time.Sleep(time.Duration(er.cfg.LockRetryInterval * float64(time.Second)))
-		}
-		if !acquired {
-			return fmt.Errorf("failed to acquire lock on %s", key)
-		}
-	}
-
-	// Execute the provided function with locks held.
-	err := fn()
-
-	// Release the locks in reverse order.
-	for i := len(leases) - 1; i >= 0; i-- {
-		l := leases[i]
-		_, errDel := er.client.Delete(ctx, l.lockKey)
-		if errDel != nil {
-			er.logger.Warn().Err(errDel).Msgf("failed to delete lock key %s", l.lockKey)
-		}
-		_, errRevoke := er.client.Revoke(ctx, l.lease)
-		if errRevoke != nil {
-			er.logger.Warn().Err(errRevoke).Msgf("failed to revoke lease for %s", l.lockKey)
-		}
-	}
-	return err
 }
 
 func (er *EtcdRegistry) Close() error {

--- a/backend/internal/registry/etcd_registry_test.go
+++ b/backend/internal/registry/etcd_registry_test.go
@@ -9,42 +9,21 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 
 	"github.com/auto-dns/auto-dns-webui/internal/config"
-	"github.com/auto-dns/auto-dns-webui/internal/dns"
 )
 
-// mockEtcdClient implements the etcdClient interface with overridable Get/Delete.
+// mockEtcdClient implements the etcdClient interface with an overridable Get.
 type mockEtcdClient struct {
-	getFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
-	delFunc    func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error)
-	deletedKey string
+	getFunc func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
 }
 
 func (m *mockEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	return m.getFunc(ctx, key, opts...)
 }
 
-func (m *mockEtcdClient) Delete(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.DeleteResponse, error) {
-	if m.delFunc != nil {
-		return m.delFunc(ctx, key, opts...)
-	}
-	m.deletedKey = key
-	return &clientv3.DeleteResponse{Deleted: 1}, nil
-}
-
-func (m *mockEtcdClient) Put(ctx context.Context, key, val string, opts ...clientv3.OpOption) (*clientv3.PutResponse, error) {
-	return nil, nil
-}
-func (m *mockEtcdClient) Grant(ctx context.Context, ttl int64) (*clientv3.LeaseGrantResponse, error) {
-	return nil, nil
-}
-func (m *mockEtcdClient) Txn(ctx context.Context) clientv3.Txn { return nil }
-func (m *mockEtcdClient) Revoke(ctx context.Context, id clientv3.LeaseID) (*clientv3.LeaseRevokeResponse, error) {
-	return nil, nil
-}
 func (m *mockEtcdClient) Close() error { return nil }
 
 func newTestRegistry(client etcdClient) *EtcdRegistry {
-	return NewEtcdRegistry(client, &config.EtcdConfig{PathPrefix: "/skydns"}, "testhost", zerolog.Nop())
+	return NewEtcdRegistry(client, &config.EtcdConfig{PathPrefix: "/skydns"}, zerolog.Nop())
 }
 
 func TestParseEtcdValue(t *testing.T) {
@@ -137,24 +116,4 @@ func TestList(t *testing.T) {
 			t.Fatal("expected error to propagate from client.Get")
 		}
 	})
-}
-
-func TestRemove(t *testing.T) {
-	client := &mockEtcdClient{
-		getFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
-			return &clientv3.GetResponse{Kvs: []*mvccpb.KeyValue{
-				{Key: []byte("/skydns/com/example/app/x1"), Value: []byte(`{"host":"10.0.0.1","record_type":"A","owner_hostname":"h1","owner_container_name":"web","created":"2024-01-02T03:04:05Z"}`)},
-			}}, nil
-		},
-	}
-	rec := &dns.Record{
-		Dns:  dns.DnsRecord{Name: "app.example.com", Type: "A", Value: "10.0.0.1"},
-		Meta: dns.RecordMetadata{Hostname: "h1", ContainerName: "web"},
-	}
-	if err := newTestRegistry(client).Remove(context.Background(), rec); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if client.deletedKey != "/skydns/com/example/app/x1" {
-		t.Errorf("deleted key = %q, want /skydns/com/example/app/x1", client.deletedKey)
-	}
 }

--- a/backend/internal/registry/registry.go
+++ b/backend/internal/registry/registry.go
@@ -7,8 +7,6 @@ import (
 )
 
 type Registry interface {
-	LockTransaction(ctx context.Context, key []string, fn func() error) error
 	List(ctx context.Context) ([]*dns.Record, error)
-	Remove(ctx context.Context, record *dns.Record) error
 	Close() error
 }

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -19,7 +19,7 @@ type Server struct {
 	handler api.HandlerInterface
 }
 
-func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, cfg *config.ServerConfig, logger zerolog.Logger) *Server {
+func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, cfg *config.ServerConfig, logger zerolog.Logger) (*Server, error) {
 	s := &Server{
 		cfg:     cfg,
 		logger:  logger,
@@ -27,22 +27,29 @@ func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, cf
 		http:    http,
 		handler: handler,
 	}
-	s.registerRoutes()
-	return s
+	if err := s.registerRoutes(); err != nil {
+		return nil, err
+	}
+	return s, nil
 }
 
-func (s *Server) registerRoutes() {
+func (s *Server) registerRoutes() error {
 	// API routes
 	s.mux.HandleFunc("/api/records", s.handler.Records)
 
 	// Frontend
 	if s.cfg.Proxy.Enable {
-		s.logger.Debug().Msg("Proxying frontend to Vite")
-		s.mux.Handle("/", frontend.ProxyToVite())
+		s.logger.Debug().Str("hostname", s.cfg.Proxy.Hostname).Int("port", s.cfg.Proxy.Port).Msg("Proxying frontend to Vite")
+		proxy, err := frontend.ProxyToVite(s.cfg.Proxy.Hostname, s.cfg.Proxy.Port)
+		if err != nil {
+			return err
+		}
+		s.mux.Handle("/", proxy)
 	} else {
 		s.logger.Debug().Msg("Serving embedded frontend")
 		s.mux.Handle("/", frontend.ServeStatic())
 	}
+	return nil
 }
 
 func (s *Server) Start(ctx context.Context) error {

--- a/backend/internal/version/version.go
+++ b/backend/internal/version/version.go
@@ -1,0 +1,11 @@
+// Package version exposes the application version.
+package version
+
+// Version is the application version. It defaults to "dev" for local and
+// unstamped builds, and is overridden at build time via:
+//
+//	-ldflags "-X github.com/auto-dns/auto-dns-webui/internal/version.Version=<v>"
+//
+// (see the Dockerfile's VERSION build arg). Release images are stamped with the
+// git tag.
+var Version = "dev"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-dns-webui",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/pages/RecordList/RecordList.module.scss
+++ b/frontend/src/pages/RecordList/RecordList.module.scss
@@ -110,6 +110,30 @@
       font-weight: 600;
       text-align: center;
     }
+
+    .statusMessage {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 2.5rem 1rem;
+      text-align: center;
+      color: var(--text-color);
+    }
+
+    .retryButton {
+      padding: 0.5rem 1.25rem;
+      font-size: 0.95rem;
+      color: var(--text-color);
+      background-color: var(--card-bg);
+      border: 1px solid var(--card-border);
+      border-radius: 6px;
+      cursor: pointer;
+
+      &:hover {
+        background-color: var(--card-border);
+      }
+    }
   }
 }
 

--- a/frontend/src/pages/RecordList/RecordList.tsx
+++ b/frontend/src/pages/RecordList/RecordList.tsx
@@ -38,6 +38,8 @@ export default function RecordList() {
 
   // Declare state
   const [records, setRecords] = useState<RecordEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [showSidebar, setShowSidebar] = useSidebarState();
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState(initialState.search);
@@ -48,13 +50,32 @@ export default function RecordList() {
   // Track if we should update URL (to avoid infinite loops during initialization)
   const isInitializing = useRef(true);
 
+  // Fetch records (retryable)
+  const loadRecords = useCallback(() => {
+    setLoading(true);
+    setError(null);
+    fetch('/api/records')
+      .then((res) => {
+        if (!res.ok) {
+          throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+        }
+        return res.json();
+      })
+      .then((data: RecordEntry[]) => {
+        setRecords(data);
+        setLoading(false);
+      })
+      .catch((err) => {
+        console.error('Failed to fetch records:', err);
+        setError('Failed to load DNS records. Please try again.');
+        setLoading(false);
+      });
+  }, []);
+
   // Use effects
   useEffect(() => {
-    fetch('/api/records')
-      .then((res) => res.json())
-      .then((data) => setRecords(data))
-      .catch((err) => console.error('Failed to fetch records:', err));
-  }, []);
+    loadRecords();
+  }, [loadRecords]);
 
   useEffect(() => {
     const onScroll = () => {
@@ -155,11 +176,24 @@ export default function RecordList() {
           </div>
         </header>
         <h2 className={styles.pageTitle}>DNS Records</h2>
-        <RecordGrid
-          records={sortedRecords}
-          expandedKeys={expandedKeys}
-          toggleExpand={toggleExpand}
-        />
+        {loading ? (
+          <div className={styles.statusMessage} role='status' aria-live='polite'>
+            Loading records…
+          </div>
+        ) : error ? (
+          <div className={styles.statusMessage} role='alert'>
+            <p>{error}</p>
+            <button className={styles.retryButton} onClick={loadRecords}>
+              Retry
+            </button>
+          </div>
+        ) : (
+          <RecordGrid
+            records={sortedRecords}
+            expandedKeys={expandedKeys}
+            toggleExpand={toggleExpand}
+          />
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

Merges the **correctness milestone** (`v0.6.0`) into `main` and prepares the release. Once merged, tag `v0.6.0` to trigger the GHCR image build and the GitHub Release (cut from the `## [0.6.0]` CHANGELOG section).

### What's in this milestone

- **#18 — Dev Vite proxy ignored its config.** `ProxyToVite` now builds its target from `server.proxy.hostname` / `server.proxy.port` (was hardcoded `http://localhost:5173`) and returns an error instead of `log.Fatalf`; the error is threaded through `server.New` → `app.NewServer` → `app.New`. Added a test that verifies requests reach the configured target.
- **#19 — Removed dead write-path code.** This read-only app no longer carries the unused `Registry.Remove` / `Registry.LockTransaction` methods; the `etcdClient` interface is slimmed to `Get`/`Close`; and the previously **required** etcd lock config (`etcd.lock_ttl`, `etcd.lock_timeout`, `etcd.lock_retry_interval` + flags) is gone, so operators no longer set meaningless values to boot.
- **#20 — Frontend loading/error states + backend cosmetics.** The record list shows a loading indicator and an error state with a **Retry** button instead of a blank page when `/api/records` fails. The MCP server reports a build-stamped version (`internal/version`, injected via `-ldflags` + the Dockerfile `VERSION` build arg, wired through the release workflow) instead of a hardcoded `1.0.0`; the `dns.DnsRecord.Type` comment now notes `AAAA`.

### Release prep

- `CHANGELOG.md`: `## [Unreleased]` renamed to `## [0.6.0] - 2026-06-26`.
- `frontend/package.json`: bumped `0.5.0` → `0.6.0` (closes **#58**).

## Linked issues

Closes #18
Closes #19
Closes #20
Closes #58

## Checklist

- [x] CI green on the milestone branch (backend vet/lint/test, frontend lint/typecheck/build)
- [x] `CHANGELOG.md` finalized under the `## [0.6.0]` heading
- [x] `frontend/package.json` version bumped to `0.6.0`
- [x] No change to the minimum compatible `docker-coredns-sync` version — the consumed etcd schema is unaffected

## After merge

Tag `v0.6.0` on `main` to publish the GHCR image and GitHub Release. The released image's MCP server will report `0.6.0` via the new build stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HFcqhbjrthUQeiwM8v7MEv)_