### PR TITLE
feat: live record refresh via SSE stream with polling fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Live record refresh. The record list now stays current without a manual page
+  reload: the backend exposes a Server-Sent Events endpoint
+  (`GET /api/records/stream`) backed by a single etcd `Watch` on the configured
+  `path_prefix`, fanning record snapshots out to all connected clients. The web
+  UI consumes the stream and falls back to polling `/api/records` when SSE is
+  unavailable (e.g. behind a buffering proxy), pausing updates while the tab is
+  hidden. A connection-status indicator, a "last updated" time, and a manual
+  **Refresh** control were added to the UI. New Prometheus gauge
+  `auto_dns_webui_stream_clients` reports the number of connected stream clients
+  (#23).
+
+### Notes
+- Purely additive: no change to the existing public contract (`/api/records`,
+  `AUTO_DNS_WEBUI_*` config, MCP tool schemas) or to the consumed
+  `docker-coredns-sync` etcd record schema — the new stream endpoint reads the
+  same records, so the minimum compatible producer version is unchanged.
+
 ## [0.7.0] - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Live record refresh. The record list now stays current without a manual page
   reload: the backend exposes a Server-Sent Events endpoint
   (`GET /api/records/stream`) backed by a single etcd `Watch` on the configured
-  `path_prefix`, fanning record snapshots out to all connected clients. The web
-  UI consumes the stream and falls back to polling `/api/records` when SSE is
-  unavailable (e.g. behind a buffering proxy), pausing updates while the tab is
-  hidden. A connection-status indicator, a "last updated" time, and a manual
-  **Refresh** control were added to the UI. New Prometheus gauge
+  `path_prefix`, fanning record snapshots out to all connected clients, with a
+  periodic `ping` heartbeat event. The web UI consumes the stream and falls back
+  to polling `/api/records` when SSE is unavailable, errors, or opens but goes
+  silent (e.g. behind a buffering proxy — detected via a heartbeat watchdog),
+  pausing updates while the tab is hidden. A connection-status indicator, a
+  "last updated" time, and a manual **Refresh** control were added to the UI.
+  New Prometheus gauge
   `auto_dns_webui_stream_clients` reports the number of connected stream clients
   (#23).
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ data: [{"dnsRecord":{...},"metadata":{...}}, ...]
 
 ```
 
-Idle connections receive a `: ping` comment roughly every 25 seconds to keep proxies from dropping them. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable (e.g. behind a proxy that buffers responses).
+Idle connections receive a `ping` event roughly every 25 seconds to keep proxies from dropping them and to give clients a liveness signal. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable, errors, or opens but goes silent (e.g. behind a proxy that buffers responses) — if no `records` update or `ping` arrives within ~40 seconds the UI switches to polling.
 
 ### Health probes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It optionally exposes an MCP (Model Context Protocol) server so AI tools like Cl
 
 - Browse all A/AAAA/CNAME records registered in etcd (SkyDNS format)
 - Filter by name, type, or source host
+- Live updates: the record list refreshes automatically as etcd changes (server-pushed over SSE, with polling fallback), plus a manual refresh and a "last updated" indicator
 - Optional MCP server: `list_dns_records`, `get_dns_record`, `get_records_by_host`
 
 ---
@@ -112,11 +113,26 @@ The HTTP server (`server.port`, default `8080`) exposes:
 |---|---|
 | `/` | The web UI (embedded SPA) |
 | `/api/records` | JSON list of all DNS records |
+| `/api/records/stream` | Server-Sent Events stream of record snapshots (see below) |
 | `/healthz` | Liveness — always `200 OK` while the process is serving. Does not touch etcd. |
 | `/readyz` | Readiness — `200 OK` when etcd is reachable, `503 Service Unavailable` otherwise (bounded by a short timeout). Use this as a container/orchestrator readiness probe. |
 | `/metrics` | Prometheus metrics (see below). |
 
 When the MCP server is enabled it also serves `/healthz` and `/readyz` on `mcp.port`, so the second server can be probed independently.
+
+### Live record stream
+
+`GET /api/records/stream` is a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) endpoint that keeps the UI current without manual reloads. The backend runs a single etcd `Watch` on the configured `path_prefix` and fans changes out to all connected clients, so the cost on etcd is constant regardless of how many browsers are open.
+
+On connect, and again whenever the record set changes, the server emits a `records` event whose `data` is the same JSON array returned by `/api/records`:
+
+```
+event: records
+data: [{"dnsRecord":{...},"metadata":{...}}, ...]
+
+```
+
+Idle connections receive a `: ping` comment roughly every 25 seconds to keep proxies from dropping them. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable (e.g. behind a proxy that buffers responses).
 
 ### Health probes
 
@@ -139,6 +155,7 @@ healthcheck:
 | `auto_dns_webui_http_requests_total` | counter | `route`, `method`, `code` | HTTP requests handled (API and health routes) |
 | `auto_dns_webui_http_request_duration_seconds` | histogram | `route`, `method` | HTTP request latency |
 | `auto_dns_webui_dns_records` | gauge | — | Records returned by the most recent successful etcd list |
+| `auto_dns_webui_stream_clients` | gauge | — | Currently connected record-stream (SSE) clients |
 | `auto_dns_webui_etcd_list_errors_total` | counter | — | Errors while listing records from etcd |
 | `auto_dns_webui_mcp_tool_calls_total` | counter | `tool` | MCP tool invocations by tool name |
 

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -22,8 +22,11 @@ type mockRegistry struct {
 }
 
 func (m *mockRegistry) List(ctx context.Context) ([]*dns.Record, error) { return m.records, m.err }
-func (m *mockRegistry) Ping(ctx context.Context) error                  { return m.err }
-func (m *mockRegistry) Close() error                                    { return nil }
+func (m *mockRegistry) Watch(ctx context.Context) (<-chan struct{}, error) {
+	return nil, m.err
+}
+func (m *mockRegistry) Ping(ctx context.Context) error { return m.err }
+func (m *mockRegistry) Close() error                   { return nil }
 
 func TestRecords_Success(t *testing.T) {
 	reg := &mockRegistry{records: []*dns.Record{

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/auto-dns/auto-dns-webui/internal/metrics"
 	"github.com/auto-dns/auto-dns-webui/internal/registry"
 	"github.com/auto-dns/auto-dns-webui/internal/server"
+	"github.com/auto-dns/auto-dns-webui/internal/stream"
 	"github.com/rs/zerolog"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -20,6 +21,7 @@ import (
 type App struct {
 	Logger    zerolog.Logger
 	Server    httpServer
+	Broker    *stream.Broker
 	MCPServer *http.Server
 }
 
@@ -39,7 +41,7 @@ func NewHandler(r registry.Registry, m *metrics.Metrics, logger zerolog.Logger) 
 	return api.NewHandler(r, m, logger)
 }
 
-func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHandler *health.Handler, m *metrics.Metrics, logger zerolog.Logger) (httpServer, error) {
+func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHandler *health.Handler, m *metrics.Metrics, broker http.Handler, logger zerolog.Logger) (httpServer, error) {
 	mux := http.NewServeMux()
 
 	http := &http.Server{
@@ -47,7 +49,7 @@ func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHan
 		Handler: mux,
 	}
 
-	return server.New(http, mux, handler, healthHandler, m, cfg, logger)
+	return server.New(http, mux, handler, healthHandler, m, broker, cfg, logger)
 }
 
 // New creates a new App by wiring up all dependencies.
@@ -60,8 +62,9 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	m := metrics.New()
 	handler := NewHandler(reg, m, logger)
 	healthHandler := health.New(reg, logger)
+	broker := stream.NewBroker(reg, m, logger)
 
-	srv, err := NewServer(&cfg.Server, handler, healthHandler, m, logger)
+	srv, err := NewServer(&cfg.Server, handler, healthHandler, m, broker, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server: %w", err)
 	}
@@ -91,6 +94,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	return &App{
 		Logger:    logger,
 		Server:    srv,
+		Broker:    broker,
 		MCPServer: mcpHTTP,
 	}, nil
 }
@@ -98,6 +102,10 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 // Run starts the application by running the sync engine.
 func (a *App) Run(ctx context.Context) error {
 	a.Logger.Info().Msg("Application starting")
+
+	if a.Broker != nil {
+		go a.Broker.Run(ctx)
+	}
 
 	if a.MCPServer != nil {
 		go func() {

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	httpDuration   *prometheus.HistogramVec
 	etcdListErrors prometheus.Counter
 	recordCount    prometheus.Gauge
+	streamClients  prometheus.Gauge
 	mcpToolCalls   *prometheus.CounterVec
 }
 
@@ -49,6 +50,10 @@ func New() *Metrics {
 			Name: "auto_dns_webui_dns_records",
 			Help: "Number of DNS records returned by the most recent successful etcd list.",
 		}),
+		streamClients: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "auto_dns_webui_stream_clients",
+			Help: "Number of currently connected record-stream (SSE) clients.",
+		}),
 		mcpToolCalls: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "auto_dns_webui_mcp_tool_calls_total",
 			Help: "Total number of MCP tool invocations, by tool name.",
@@ -59,6 +64,7 @@ func New() *Metrics {
 		m.httpDuration,
 		m.etcdListErrors,
 		m.recordCount,
+		m.streamClients,
 		m.mcpToolCalls,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
@@ -90,6 +96,12 @@ func (m *Metrics) SetRecordCount(n int) { m.recordCount.Set(float64(n)) }
 
 // RecordEtcdListError increments the etcd list-error counter.
 func (m *Metrics) RecordEtcdListError() { m.etcdListErrors.Inc() }
+
+// IncStreamClients records a newly connected record-stream client.
+func (m *Metrics) IncStreamClients() { m.streamClients.Inc() }
+
+// DecStreamClients records a disconnected record-stream client.
+func (m *Metrics) DecStreamClients() { m.streamClients.Dec() }
 
 // RecordMCPToolCall increments the call counter for the named MCP tool.
 func (m *Metrics) RecordMCPToolCall(tool string) { m.mcpToolCalls.WithLabelValues(tool).Inc() }

--- a/backend/internal/registry/etcd_registry.go
+++ b/backend/internal/registry/etcd_registry.go
@@ -17,6 +17,7 @@ import (
 // etcdClient is the subset of clientv3.Client this read-only app needs.
 type etcdClient interface {
 	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 	Close() error
 }
 
@@ -109,6 +110,44 @@ func (er *EtcdRegistry) List(ctx context.Context) ([]*dns.Record, error) {
 		records = append(records, record)
 	}
 	return records, nil
+}
+
+// Watch establishes an etcd watch on the configured prefix and returns a
+// channel that emits a value whenever the record set under that prefix changes.
+// Notifications are coalesced: the channel has a buffer of one and a pending
+// notification is dropped rather than blocking, so a burst of etcd events
+// surfaces as a single "something changed" signal — consumers re-List to get
+// the current state. The channel is closed when the watch ends (ctx cancelled,
+// or the watch is cancelled/errors by etcd), which signals the consumer to
+// re-establish it.
+func (er *EtcdRegistry) Watch(ctx context.Context) (<-chan struct{}, error) {
+	wch := er.client.Watch(ctx, er.cfg.PathPrefix, clientv3.WithPrefix())
+	out := make(chan struct{}, 1)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case resp, ok := <-wch:
+				if !ok {
+					return
+				}
+				if err := resp.Err(); err != nil {
+					er.logger.Error().Err(err).Msg("etcd watch error")
+					return
+				}
+				if len(resp.Events) == 0 {
+					continue
+				}
+				select {
+				case out <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+	return out, nil
 }
 
 // Ping performs a cheap reachability check against etcd. It issues a bounded,

--- a/backend/internal/registry/etcd_registry_test.go
+++ b/backend/internal/registry/etcd_registry_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
@@ -11,13 +12,19 @@ import (
 	"github.com/auto-dns/auto-dns-webui/internal/config"
 )
 
-// mockEtcdClient implements the etcdClient interface with an overridable Get.
+// mockEtcdClient implements the etcdClient interface with an overridable Get
+// and Watch.
 type mockEtcdClient struct {
-	getFunc func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	getFunc   func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	watchFunc func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 }
 
 func (m *mockEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	return m.getFunc(ctx, key, opts...)
+}
+
+func (m *mockEtcdClient) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+	return m.watchFunc(ctx, key, opts...)
 }
 
 func (m *mockEtcdClient) Close() error { return nil }
@@ -114,6 +121,85 @@ func TestList(t *testing.T) {
 		}
 		if _, err := newTestRegistry(client).List(context.Background()); err == nil {
 			t.Fatal("expected error to propagate from client.Get")
+		}
+	})
+}
+
+func TestWatch(t *testing.T) {
+	t.Run("emits a coalesced signal on change events and closes when the watch ends", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse, 1)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		out, err := newTestRegistry(client).Watch(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wch <- clientv3.WatchResponse{Events: []*clientv3.Event{{}}}
+		select {
+		case _, ok := <-out:
+			if !ok {
+				t.Fatal("channel closed; expected a change signal")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for change signal")
+		}
+
+		// Closing the upstream watch should close the returned channel.
+		close(wch)
+		select {
+		case _, ok := <-out:
+			if ok {
+				t.Fatal("expected channel to be closed after watch ended")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for channel close")
+		}
+	})
+
+	t.Run("ignores responses with no events", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse, 1)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		out, err := newTestRegistry(client).Watch(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wch <- clientv3.WatchResponse{} // no events
+		select {
+		case <-out:
+			t.Fatal("did not expect a signal for an empty watch response")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("stops when context is cancelled", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		out, err := newTestRegistry(client).Watch(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cancel()
+		select {
+		case _, ok := <-out:
+			if ok {
+				t.Fatal("expected channel to close after context cancel")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for channel close after cancel")
 		}
 	})
 }

--- a/backend/internal/registry/registry.go
+++ b/backend/internal/registry/registry.go
@@ -8,6 +8,10 @@ import (
 
 type Registry interface {
 	List(ctx context.Context) ([]*dns.Record, error)
+	// Watch returns a channel that emits whenever the record set changes,
+	// allowing the record stream to push live updates. The channel is closed
+	// when the underlying watch ends and should be re-established by the caller.
+	Watch(ctx context.Context) (<-chan struct{}, error)
 	// Ping is a cheap reachability check against the backing store, used by the
 	// readiness probe.
 	Ping(ctx context.Context) error

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -21,9 +21,10 @@ type Server struct {
 	handler api.HandlerInterface
 	health  *health.Handler
 	metrics *metrics.Metrics
+	stream  http.Handler
 }
 
-func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, health *health.Handler, metrics *metrics.Metrics, cfg *config.ServerConfig, logger zerolog.Logger) (*Server, error) {
+func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, health *health.Handler, metrics *metrics.Metrics, stream http.Handler, cfg *config.ServerConfig, logger zerolog.Logger) (*Server, error) {
 	s := &Server{
 		cfg:     cfg,
 		logger:  logger,
@@ -32,6 +33,7 @@ func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, he
 		handler: handler,
 		health:  health,
 		metrics: metrics,
+		stream:  stream,
 	}
 	if err := s.registerRoutes(); err != nil {
 		return nil, err
@@ -42,6 +44,14 @@ func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, he
 func (s *Server) registerRoutes() error {
 	// API routes (instrumented for request/latency metrics).
 	s.mux.Handle("/api/records", s.metrics.InstrumentHandler("/api/records", http.HandlerFunc(s.handler.Records)))
+
+	// Live record stream (SSE). Deliberately not wrapped in the latency
+	// histogram: these are long-lived connections, so a request-duration
+	// observation (recorded only on disconnect) would be meaningless. Connected
+	// clients are tracked by the stream gauge instead.
+	if s.stream != nil {
+		s.mux.Handle("/api/records/stream", s.stream)
+	}
 
 	// Operational endpoints.
 	s.mux.Handle("/healthz", s.metrics.InstrumentHandler("/healthz", http.HandlerFunc(s.health.Healthz)))

--- a/backend/internal/stream/broker.go
+++ b/backend/internal/stream/broker.go
@@ -1,0 +1,233 @@
+// Package stream pushes live DNS record updates to connected clients over
+// Server-Sent Events (SSE).
+//
+// A single Broker owns one etcd watch (via the registry) and fans changes out
+// to every connected client, so the cost on etcd is constant regardless of how
+// many browsers are watching. On each change the broker re-lists the full
+// record set and broadcasts it as a JSON snapshot identical in shape to
+// GET /api/records — clients simply replace their state, which keeps the wire
+// protocol and the frontend trivial.
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+	"github.com/rs/zerolog"
+)
+
+// Source supplies the current record set and a change signal. *EtcdRegistry
+// satisfies it.
+type Source interface {
+	List(ctx context.Context) ([]*dns.Record, error)
+	Watch(ctx context.Context) (<-chan struct{}, error)
+}
+
+// Metrics is the subset of *metrics.Metrics the broker reports to.
+type Metrics interface {
+	IncStreamClients()
+	DecStreamClients()
+}
+
+const (
+	// heartbeatInterval bounds how long a stream can sit idle before the broker
+	// writes an SSE comment, keeping intermediary proxies from dropping it and
+	// letting the server notice a dead client.
+	heartbeatInterval = 25 * time.Second
+
+	// minBackoff/maxBackoff bound the retry delay when the etcd watch ends and
+	// must be re-established.
+	minBackoff = 1 * time.Second
+	maxBackoff = 30 * time.Second
+)
+
+// subscriber is one connected SSE client. ch carries pre-encoded snapshot
+// payloads; it is buffered with capacity one and coalesced so a slow client
+// only ever falls behind to the latest snapshot, never blocks the broker.
+type subscriber struct {
+	ch chan []byte
+}
+
+// Broker watches etcd and fans record snapshots out to SSE subscribers.
+type Broker struct {
+	source  Source
+	metrics Metrics
+	logger  zerolog.Logger
+
+	mu     sync.Mutex
+	subs   map[*subscriber]struct{}
+	latest []byte // most recent snapshot, replayed to new subscribers
+}
+
+// NewBroker creates a Broker. Call Run to start watching; register the Broker
+// as an http.Handler to serve the SSE endpoint.
+func NewBroker(source Source, metrics Metrics, logger zerolog.Logger) *Broker {
+	return &Broker{
+		source:  source,
+		metrics: metrics,
+		logger:  logger,
+		subs:    make(map[*subscriber]struct{}),
+	}
+}
+
+// Run drives the watch loop until ctx is cancelled, re-establishing the etcd
+// watch with capped exponential backoff whenever it ends.
+func (b *Broker) Run(ctx context.Context) {
+	backoff := minBackoff
+	for ctx.Err() == nil {
+		err := b.watchLoop(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			b.logger.Error().Err(err).Dur("retry_in", backoff).Msg("record watch ended; retrying")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// watchLoop establishes one watch, pushes an initial snapshot, and broadcasts a
+// fresh snapshot on every change until the watch ends or ctx is cancelled.
+func (b *Broker) watchLoop(ctx context.Context) error {
+	wch, err := b.source.Watch(ctx)
+	if err != nil {
+		return fmt.Errorf("establishing watch: %w", err)
+	}
+	// Snapshot current state so newly (re)connected clients are immediately
+	// up to date without waiting for the next etcd change.
+	b.refresh(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-wch:
+			if !ok {
+				return errors.New("watch channel closed")
+			}
+			b.refresh(ctx)
+		}
+	}
+}
+
+// refresh lists the current records, encodes them, and broadcasts the snapshot
+// to all subscribers. List/encode failures are logged and skipped — the last
+// good snapshot stays in place.
+func (b *Broker) refresh(ctx context.Context) {
+	records, err := b.source.List(ctx)
+	if err != nil {
+		b.logger.Error().Err(err).Msg("failed to list records for stream update")
+		return
+	}
+	if records == nil {
+		records = []*dns.Record{}
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		b.logger.Error().Err(err).Msg("failed to encode records for stream update")
+		return
+	}
+
+	b.mu.Lock()
+	b.latest = data
+	for s := range b.subs {
+		send(s.ch, data)
+	}
+	b.mu.Unlock()
+}
+
+// send delivers data to a capacity-one channel without blocking, replacing any
+// stale queued snapshot so the client always converges on the newest state.
+func send(ch chan []byte, data []byte) {
+	for {
+		select {
+		case ch <- data:
+			return
+		default:
+			select {
+			case <-ch:
+			default:
+			}
+		}
+	}
+}
+
+func (b *Broker) subscribe() *subscriber {
+	s := &subscriber{ch: make(chan []byte, 1)}
+	b.mu.Lock()
+	if b.latest != nil {
+		s.ch <- b.latest // safe: buffer cap 1, freshly created and empty
+	}
+	b.subs[s] = struct{}{}
+	b.mu.Unlock()
+	b.metrics.IncStreamClients()
+	return s
+}
+
+func (b *Broker) unsubscribe(s *subscriber) {
+	b.mu.Lock()
+	_, ok := b.subs[s]
+	delete(b.subs, s)
+	b.mu.Unlock()
+	if ok {
+		b.metrics.DecStreamClients()
+	}
+}
+
+// ServeHTTP implements the SSE endpoint: it holds the connection open and
+// writes a `records` event (current snapshot, then one per change) plus
+// periodic heartbeat comments until the client disconnects.
+func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no") // tell nginx not to buffer the stream
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	sub := b.subscribe()
+	defer b.unsubscribe(sub)
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data := <-sub.ch:
+			// Compact JSON never contains a newline, so a single data: line is
+			// a valid SSE frame.
+			if _, err := fmt.Fprintf(w, "event: records\ndata: %s\n\n", data); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/backend/internal/stream/broker.go
+++ b/backend/internal/stream/broker.go
@@ -189,7 +189,7 @@ func (b *Broker) unsubscribe(s *subscriber) {
 
 // ServeHTTP implements the SSE endpoint: it holds the connection open and
 // writes a `records` event (current snapshot, then one per change) plus
-// periodic heartbeat comments until the client disconnects.
+// periodic `ping` heartbeat events until the client disconnects.
 func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -224,7 +224,11 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			flusher.Flush()
 		case <-heartbeat.C:
-			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+			// A named `ping` event (rather than a bare comment) keeps proxies
+			// from dropping the connection *and* gives clients a visible
+			// liveness signal so they can tell an idle-but-healthy stream from a
+			// stalled one (EventSource does not surface comment lines to JS).
+			if _, err := fmt.Fprint(w, "event: ping\ndata: {}\n\n"); err != nil {
 				return
 			}
 			flusher.Flush()

--- a/backend/internal/stream/broker_test.go
+++ b/backend/internal/stream/broker_test.go
@@ -1,0 +1,184 @@
+package stream
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// fakeSource is a controllable Source for broker tests.
+type fakeSource struct {
+	mu      sync.Mutex
+	records []*dns.Record
+	watchCh chan struct{}
+	listed  chan struct{} // signalled after each List call (best-effort)
+}
+
+func (f *fakeSource) setRecords(recs []*dns.Record) {
+	f.mu.Lock()
+	f.records = recs
+	f.mu.Unlock()
+}
+
+func (f *fakeSource) List(ctx context.Context) ([]*dns.Record, error) {
+	f.mu.Lock()
+	recs := f.records
+	f.mu.Unlock()
+	if f.listed != nil {
+		select {
+		case f.listed <- struct{}{}:
+		default:
+		}
+	}
+	return recs, nil
+}
+
+func (f *fakeSource) Watch(ctx context.Context) (<-chan struct{}, error) {
+	return f.watchCh, nil
+}
+
+type fakeMetrics struct {
+	mu  sync.Mutex
+	cur int
+}
+
+func (m *fakeMetrics) IncStreamClients() {
+	m.mu.Lock()
+	m.cur++
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) DecStreamClients() {
+	m.mu.Lock()
+	m.cur--
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cur
+}
+
+func rec(name string) *dns.Record {
+	return &dns.Record{Dns: dns.DnsRecord{Name: name, Type: "A", Value: "10.0.0.1"}}
+}
+
+// readEvent reads one SSE frame (skipping heartbeat comments) and returns the
+// event name and the data payload.
+func readEvent(t *testing.T, r *bufio.Reader) (event, data string) {
+	t.Helper()
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading stream: %v", err)
+		}
+		line = strings.TrimRight(line, "\n")
+		switch {
+		case strings.HasPrefix(line, ":"):
+			continue // heartbeat comment
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		case line == "":
+			if event != "" || data != "" {
+				return event, data
+			}
+		}
+	}
+}
+
+func TestBrokerServeHTTP(t *testing.T) {
+	src := &fakeSource{records: []*dns.Record{rec("app.example.com")}, watchCh: make(chan struct{}, 1)}
+	m := &fakeMetrics{}
+	b := NewBroker(src, m, zerolog.Nop())
+
+	// Populate the latest snapshot so a freshly connected client receives it.
+	b.refresh(context.Background())
+
+	srv := httptest.NewServer(b)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content-type = %q, want text/event-stream", ct)
+	}
+
+	r := bufio.NewReader(resp.Body)
+
+	// Initial snapshot replay.
+	event, data := readEvent(t, r)
+	if event != "records" {
+		t.Fatalf("event = %q, want records", event)
+	}
+	if !strings.Contains(data, "app.example.com") {
+		t.Fatalf("initial snapshot missing record: %s", data)
+	}
+
+	// A change broadcasts a fresh snapshot.
+	src.setRecords([]*dns.Record{rec("db.example.com")})
+	b.refresh(context.Background())
+	event, data = readEvent(t, r)
+	if event != "records" || !strings.Contains(data, "db.example.com") {
+		t.Fatalf("update snapshot wrong: event=%q data=%s", event, data)
+	}
+
+	// Client is counted while connected.
+	if got := m.count(); got != 1 {
+		t.Fatalf("stream client count = %d, want 1", got)
+	}
+
+	resp.Body.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for m.count() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("stream client count = %d after disconnect, want 0", m.count())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestBrokerRunRefreshesOnWatch(t *testing.T) {
+	src := &fakeSource{
+		records: []*dns.Record{rec("app.example.com")},
+		watchCh: make(chan struct{}, 1),
+		listed:  make(chan struct{}, 8),
+	}
+	b := NewBroker(src, &fakeMetrics{}, zerolog.Nop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.Run(ctx)
+
+	// Initial refresh on watch establishment.
+	waitListed(t, src.listed, "initial refresh")
+
+	// A watch signal triggers another List.
+	src.watchCh <- struct{}{}
+	waitListed(t, src.listed, "refresh on change")
+
+	cancel()
+}
+
+func waitListed(t *testing.T, listed chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-listed:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for List (%s)", what)
+	}
+}

--- a/backend/internal/stream/broker_test.go
+++ b/backend/internal/stream/broker_test.go
@@ -113,7 +113,7 @@ func TestBrokerServeHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connecting: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
 	}
@@ -142,7 +142,7 @@ func TestBrokerServeHTTP(t *testing.T) {
 		t.Fatalf("stream client count = %d, want 1", got)
 	}
 
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	deadline := time.Now().Add(2 * time.Second)
 	for m.count() != 0 {
 		if time.Now().After(deadline) {

--- a/frontend/src/components/StatusBar/StatusBar.module.scss
+++ b/frontend/src/components/StatusBar/StatusBar.module.scss
@@ -1,0 +1,62 @@
+@use '../../styles/variables' as *;
+
+.statusBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--text-muted);
+}
+
+.live {
+  color: #1a8f4a;
+
+  .dot {
+    background-color: #1fb05a;
+    box-shadow: 0 0 0 3px rgba(31, 176, 90, 0.2);
+  }
+}
+
+.polling .dot,
+.connecting .dot {
+  background-color: #d9a200;
+  box-shadow: 0 0 0 3px rgba(217, 162, 0, 0.2);
+}
+
+.updated {
+  white-space: nowrap;
+}
+
+.refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-color);
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--card-border);
+  }
+}

--- a/frontend/src/components/StatusBar/StatusBar.tsx
+++ b/frontend/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import classNames from 'classnames';
+import { ConnectionStatus } from '../../hooks/useRecords';
+import { formatRelativeTime } from '../../utils/time';
+import styles from './StatusBar.module.scss';
+
+interface StatusBarProps {
+  status: ConnectionStatus;
+  lastUpdated: Date | null;
+  onRefresh: () => void;
+}
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  connecting: 'Connecting…',
+  live: 'Live',
+  polling: 'Polling',
+};
+
+// How often the relative "updated Xs ago" label is recomputed.
+const TICK_MS = 10_000;
+
+export default function StatusBar({ status, lastUpdated, onRefresh }: StatusBarProps) {
+  // Re-render periodically so the relative timestamp stays current even when
+  // no new data has arrived.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className={styles.statusBar}>
+      <span
+        className={classNames(styles.indicator, styles[status])}
+        role="status"
+        aria-live="polite"
+        title={`Updates: ${STATUS_LABEL[status]}`}
+      >
+        <span className={styles.dot} aria-hidden="true" />
+        {STATUS_LABEL[status]}
+      </span>
+      {lastUpdated && (
+        <span className={styles.updated} title={lastUpdated.toLocaleString()}>
+          Updated {formatRelativeTime(lastUpdated)}
+        </span>
+      )}
+      <button
+        className={styles.refresh}
+        onClick={onRefresh}
+        aria-label="Refresh records"
+        title="Refresh records"
+      >
+        <RefreshCw size={16} />
+        Refresh
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useRecords.ts
+++ b/frontend/src/hooks/useRecords.ts
@@ -10,6 +10,12 @@ export type ConnectionStatus = 'connecting' | 'live' | 'polling';
 // How often the polling fallback re-fetches when the live stream is down.
 const POLL_INTERVAL_MS = 15_000;
 
+// If the open stream delivers nothing (no `records` update and no `ping`
+// heartbeat) within this window, treat it as stalled and fall back to polling.
+// Must exceed the server's heartbeat interval (25s) with margin so a healthy but
+// idle stream is never mistaken for a dead one.
+const STALL_TIMEOUT_MS = 40_000;
+
 export interface UseRecordsResult {
   records: RecordEntry[];
   loading: boolean;
@@ -21,8 +27,9 @@ export interface UseRecordsResult {
 
 // useRecords loads the DNS record set and keeps it live. It prefers a
 // server-pushed SSE stream (`/api/records/stream`) and transparently falls back
-// to interval polling of `/api/records` when EventSource is unavailable or the
-// stream fails. Updates pause while the tab is hidden and catch up on return.
+// to interval polling of `/api/records` when EventSource is unavailable, the
+// stream errors, or the stream opens but goes silent (e.g. behind a buffering
+// proxy). Updates pause while the tab is hidden and catch up on return.
 export function useRecords(): UseRecordsResult {
   const [records, setRecords] = useState<RecordEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,6 +39,7 @@ export function useRecords(): UseRecordsResult {
 
   const esRef = useRef<EventSource | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stallRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Apply a fresh snapshot from any source (fetch or stream).
   const applySnapshot = useCallback((data: RecordEntry[]) => {
@@ -78,6 +86,9 @@ export function useRecords(): UseRecordsResult {
   const startPolling = useCallback(() => {
     if (pollRef.current !== null) return;
     setStatus('polling');
+    // Fetch immediately so the list catches up without waiting a full interval;
+    // the interval handles subsequent refreshes (skipped while the tab is hidden).
+    void fetchRecords(false);
     pollRef.current = setInterval(() => {
       if (!document.hidden) {
         void fetchRecords(false);
@@ -85,7 +96,17 @@ export function useRecords(): UseRecordsResult {
     }, POLL_INTERVAL_MS);
   }, [fetchRecords]);
 
-  // (Re)open the SSE stream, falling back to polling if it can't be used.
+  const clearStall = useCallback(() => {
+    if (stallRef.current !== null) {
+      clearTimeout(stallRef.current);
+      stallRef.current = null;
+    }
+  }, []);
+
+  // (Re)open the SSE stream, falling back to polling if it can't be used. The
+  // stream is only considered "live" once it actually delivers something, so a
+  // connection that opens but stays silent falls back via the stall watchdog
+  // while polling keeps the data fresh in the meantime.
   const connect = useCallback(() => {
     if (typeof EventSource === 'undefined') {
       startPolling();
@@ -97,9 +118,27 @@ export function useRecords(): UseRecordsResult {
     const es = new EventSource('/api/records/stream');
     esRef.current = es;
 
-    es.addEventListener('records', (ev) => {
-      stopPolling();
+    // Re-arm the stall watchdog: if nothing arrives within the timeout, the
+    // stream is treated as dead and we fall back to polling.
+    const armStall = () => {
+      clearStall();
+      stallRef.current = setTimeout(() => {
+        esRef.current?.close();
+        esRef.current = null;
+        startPolling();
+      }, STALL_TIMEOUT_MS);
+    };
+
+    // Any traffic (a snapshot or a heartbeat) proves the stream is flowing:
+    // mark it live, stop the polling fallback, and reset the watchdog.
+    const onTraffic = () => {
       setStatus('live');
+      stopPolling();
+      armStall();
+    };
+
+    es.addEventListener('records', (ev) => {
+      onTraffic();
       try {
         const data = JSON.parse((ev as MessageEvent).data) as RecordEntry[];
         applySnapshot(data);
@@ -108,21 +147,21 @@ export function useRecords(): UseRecordsResult {
       }
     });
 
-    es.onopen = () => {
-      stopPolling();
-      setStatus('live');
-    };
+    es.addEventListener('ping', onTraffic);
 
     es.onerror = () => {
       // EventSource retries on its own while readyState === CONNECTING; only a
-      // fully closed stream means we should fall back to polling.
+      // fully closed stream means we should fall back to polling immediately.
       if (es.readyState === EventSource.CLOSED) {
+        clearStall();
         startPolling();
       } else {
         setStatus('connecting');
       }
     };
-  }, [applySnapshot, startPolling, stopPolling]);
+
+    armStall();
+  }, [applySnapshot, clearStall, startPolling, stopPolling]);
 
   // Manual refresh: immediate fetch regardless of the active transport.
   const refresh = useCallback(() => {
@@ -137,6 +176,7 @@ export function useRecords(): UseRecordsResult {
       esRef.current?.close();
       esRef.current = null;
       stopPolling();
+      clearStall();
     };
     // Run once on mount; the callbacks are stable for the component's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -149,14 +189,16 @@ export function useRecords(): UseRecordsResult {
         esRef.current?.close();
         esRef.current = null;
         stopPolling();
+        clearStall();
       } else {
-        void fetchRecords(false);
+        // connect() replays the current snapshot over SSE (or starts polling,
+        // which fetches immediately), so no separate catch-up fetch is needed.
         connect();
       }
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => document.removeEventListener('visibilitychange', onVisibility);
-  }, [connect, fetchRecords, stopPolling]);
+  }, [connect, clearStall, stopPolling]);
 
   return { records, loading, error, lastUpdated, status, refresh };
 }

--- a/frontend/src/hooks/useRecords.ts
+++ b/frontend/src/hooks/useRecords.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RecordEntry } from '../types';
+
+// Connection status surfaced to the UI:
+// - 'connecting': the live stream is being (re)established
+// - 'live':       receiving server-pushed updates over SSE
+// - 'polling':    SSE is unavailable; falling back to interval polling
+export type ConnectionStatus = 'connecting' | 'live' | 'polling';
+
+// How often the polling fallback re-fetches when the live stream is down.
+const POLL_INTERVAL_MS = 15_000;
+
+export interface UseRecordsResult {
+  records: RecordEntry[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  status: ConnectionStatus;
+  refresh: () => void;
+}
+
+// useRecords loads the DNS record set and keeps it live. It prefers a
+// server-pushed SSE stream (`/api/records/stream`) and transparently falls back
+// to interval polling of `/api/records` when EventSource is unavailable or the
+// stream fails. Updates pause while the tab is hidden and catch up on return.
+export function useRecords(): UseRecordsResult {
+  const [records, setRecords] = useState<RecordEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>('connecting');
+
+  const esRef = useRef<EventSource | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Apply a fresh snapshot from any source (fetch or stream).
+  const applySnapshot = useCallback((data: RecordEntry[]) => {
+    setRecords(data);
+    setLastUpdated(new Date());
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  // One-shot fetch of the full record set. `showLoading` drives the page-level
+  // loading/error states (initial load and manual refresh); background polling
+  // passes false so a transient blip doesn't blank the list.
+  const fetchRecords = useCallback(
+    async (showLoading: boolean) => {
+      if (showLoading) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const res = await fetch('/api/records');
+        if (!res.ok) {
+          throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+        }
+        const data = (await res.json()) as RecordEntry[];
+        applySnapshot(data);
+      } catch (err) {
+        console.error('Failed to fetch records:', err);
+        if (showLoading) {
+          setError('Failed to load DNS records. Please try again.');
+          setLoading(false);
+        }
+      }
+    },
+    [applySnapshot],
+  );
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    if (pollRef.current !== null) return;
+    setStatus('polling');
+    pollRef.current = setInterval(() => {
+      if (!document.hidden) {
+        void fetchRecords(false);
+      }
+    }, POLL_INTERVAL_MS);
+  }, [fetchRecords]);
+
+  // (Re)open the SSE stream, falling back to polling if it can't be used.
+  const connect = useCallback(() => {
+    if (typeof EventSource === 'undefined') {
+      startPolling();
+      return;
+    }
+    esRef.current?.close();
+    setStatus('connecting');
+
+    const es = new EventSource('/api/records/stream');
+    esRef.current = es;
+
+    es.addEventListener('records', (ev) => {
+      stopPolling();
+      setStatus('live');
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as RecordEntry[];
+        applySnapshot(data);
+      } catch (err) {
+        console.error('Failed to parse stream payload:', err);
+      }
+    });
+
+    es.onopen = () => {
+      stopPolling();
+      setStatus('live');
+    };
+
+    es.onerror = () => {
+      // EventSource retries on its own while readyState === CONNECTING; only a
+      // fully closed stream means we should fall back to polling.
+      if (es.readyState === EventSource.CLOSED) {
+        startPolling();
+      } else {
+        setStatus('connecting');
+      }
+    };
+  }, [applySnapshot, startPolling, stopPolling]);
+
+  // Manual refresh: immediate fetch regardless of the active transport.
+  const refresh = useCallback(() => {
+    void fetchRecords(true);
+  }, [fetchRecords]);
+
+  // Initial load + stream setup.
+  useEffect(() => {
+    void fetchRecords(true);
+    connect();
+    return () => {
+      esRef.current?.close();
+      esRef.current = null;
+      stopPolling();
+    };
+    // Run once on mount; the callbacks are stable for the component's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Pause while the tab is hidden; resume and catch up when it becomes visible.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.hidden) {
+        esRef.current?.close();
+        esRef.current = null;
+        stopPolling();
+      } else {
+        void fetchRecords(false);
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [connect, fetchRecords, stopPolling]);
+
+  return { records, loading, error, lastUpdated, status, refresh };
+}

--- a/frontend/src/pages/RecordList/RecordList.tsx
+++ b/frontend/src/pages/RecordList/RecordList.tsx
@@ -1,18 +1,19 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
-import { Filters, RecordEntry, SortState } from '../../types';
+import { Filters, SortState } from '../../types';
 import { deriveFilterOptions } from '../../utils/filters';
 import SearchBar from '../../components/SearchBar/SearchBar';
 import FilterSortDrawer from '../../components/FilterSortDrawer/FilterSortDrawer';
 import RecordGrid from '../../components/RecordGrid/RecordGrid';
+import StatusBar from '../../components/StatusBar/StatusBar';
 import { SORT_KEYS, sortRecords } from '../../utils/sort';
 import { enrichSearchable } from '../../utils/record';
 import { filterRecords, getFacetCounts } from '../../utils/filters';
 import { parseFromUrl, updateUrl } from '../../utils/url';
 import { useSidebarState } from '../../hooks/useSidebarState';
+import { useRecords } from '../../hooks/useRecords';
 import styles from './RecordList.module.scss';
 import classNames from 'classnames';
 import { PanelLeft } from 'lucide-react';
-
 
 export default function RecordList() {
   // Initialize state from URL on mount
@@ -37,46 +38,18 @@ export default function RecordList() {
   }, []);
 
   // Declare state
-  const [records, setRecords] = useState<RecordEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { records, loading, error, lastUpdated, status, refresh } = useRecords();
   const [showSidebar, setShowSidebar] = useSidebarState();
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState(initialState.search);
   const [filters, setFilters] = useState<Filters>(initialState.filters);
   const [sort, setSort] = useState<SortState>(initialState.sort);
   const [scrolled, setScrolled] = useState(false);
-  
+
   // Track if we should update URL (to avoid infinite loops during initialization)
   const isInitializing = useRef(true);
 
-  // Fetch records (retryable)
-  const loadRecords = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    fetch('/api/records')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`Request failed: ${res.status} ${res.statusText}`);
-        }
-        return res.json();
-      })
-      .then((data: RecordEntry[]) => {
-        setRecords(data);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error('Failed to fetch records:', err);
-        setError('Failed to load DNS records. Please try again.');
-        setLoading(false);
-      });
-  }, []);
-
   // Use effects
-  useEffect(() => {
-    loadRecords();
-  }, [loadRecords]);
-
   useEffect(() => {
     const onScroll = () => {
       setScrolled(window.scrollY > 0);
@@ -113,14 +86,23 @@ export default function RecordList() {
 
   // Memoize aggregated data
   const enrichedRecords = useMemo(() => enrichSearchable(records), [records]);
-  const filteredRecords = useMemo(() => filterRecords(enrichedRecords, filters, search), [enrichedRecords, filters, search]);
+  const filteredRecords = useMemo(
+    () => filterRecords(enrichedRecords, filters, search),
+    [enrichedRecords, filters, search],
+  );
   const sortedRecords = useMemo(() => sortRecords(filteredRecords, sort), [filteredRecords, sort]);
-  const facetCounts = useMemo(() => getFacetCounts(filteredRecords, filters), [filteredRecords, filters]);
-  const {recordTypes, recordValues, hostnames, forceValues} = useMemo(() => deriveFilterOptions(records), [records]);
+  const facetCounts = useMemo(
+    () => getFacetCounts(filteredRecords, filters),
+    [filteredRecords, filters],
+  );
+  const { recordTypes, recordValues, hostnames, forceValues } = useMemo(
+    () => deriveFilterOptions(records),
+    [records],
+  );
 
   // Set callbacks
   const toggleExpand = useCallback((key: string) => {
-    setExpandedKeys(prev => {
+    setExpandedKeys((prev) => {
       const updated = new Set(prev);
       updated.has(key) ? updated.delete(key) : updated.add(key);
       return updated;
@@ -164,8 +146,8 @@ export default function RecordList() {
             {!showSidebar && (
               <button
                 className={styles.hamburger}
-                onClick={() => setShowSidebar(s => !s)}
-                aria-label='Toggle filters'
+                onClick={() => setShowSidebar((s) => !s)}
+                aria-label="Toggle filters"
               >
                 <PanelLeft size={20} />
               </button>
@@ -176,14 +158,17 @@ export default function RecordList() {
           </div>
         </header>
         <h2 className={styles.pageTitle}>DNS Records</h2>
+        {!loading && !error && (
+          <StatusBar status={status} lastUpdated={lastUpdated} onRefresh={refresh} />
+        )}
         {loading ? (
-          <div className={styles.statusMessage} role='status' aria-live='polite'>
+          <div className={styles.statusMessage} role="status" aria-live="polite">
             Loading records…
           </div>
         ) : error ? (
-          <div className={styles.statusMessage} role='alert'>
+          <div className={styles.statusMessage} role="alert">
             <p>{error}</p>
-            <button className={styles.retryButton} onClick={loadRecords}>
+            <button className={styles.retryButton} onClick={refresh}>
               Retry
             </button>
           </div>

--- a/frontend/src/pages/RecordList/RecordList.tsx
+++ b/frontend/src/pages/RecordList/RecordList.tsx
@@ -44,19 +44,9 @@ export default function RecordList() {
   const [search, setSearch] = useState(initialState.search);
   const [filters, setFilters] = useState<Filters>(initialState.filters);
   const [sort, setSort] = useState<SortState>(initialState.sort);
-  const [scrolled, setScrolled] = useState(false);
 
   // Track if we should update URL (to avoid infinite loops during initialization)
   const isInitializing = useRef(true);
-
-  // Use effects
-  useEffect(() => {
-    const onScroll = () => {
-      setScrolled(window.scrollY > 0);
-    };
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   // Mark initialization as complete after first render
   useEffect(() => {

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from './time';
+
+describe('formatRelativeTime', () => {
+  const base = new Date('2026-06-26T12:00:00Z');
+
+  const at = (secondsAgo: number) => new Date(base.getTime() - secondsAgo * 1000);
+
+  it('renders "just now" for very recent times', () => {
+    expect(formatRelativeTime(at(0), base)).toBe('just now');
+    expect(formatRelativeTime(at(4), base)).toBe('just now');
+  });
+
+  it('renders seconds', () => {
+    expect(formatRelativeTime(at(5), base)).toBe('5s ago');
+    expect(formatRelativeTime(at(59), base)).toBe('59s ago');
+  });
+
+  it('renders minutes', () => {
+    expect(formatRelativeTime(at(60), base)).toBe('1m ago');
+    expect(formatRelativeTime(at(59 * 60), base)).toBe('59m ago');
+  });
+
+  it('renders hours', () => {
+    expect(formatRelativeTime(at(60 * 60), base)).toBe('1h ago');
+    expect(formatRelativeTime(at(23 * 60 * 60), base)).toBe('23h ago');
+  });
+
+  it('renders days', () => {
+    expect(formatRelativeTime(at(24 * 60 * 60), base)).toBe('1d ago');
+  });
+
+  it('treats future timestamps as "just now"', () => {
+    expect(formatRelativeTime(at(-10), base)).toBe('just now');
+  });
+});

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,14 @@
+// formatRelativeTime renders a short, human-friendly "time ago" string for the
+// last-updated indicator (e.g. "just now", "12s ago", "3m ago", "2h ago").
+export function formatRelativeTime(from: Date, now: Date = new Date()): string {
+  const seconds = Math.round((now.getTime() - from.getTime()) / 1000);
+  if (seconds < 0) return 'just now';
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -2,7 +2,7 @@
 // last-updated indicator (e.g. "just now", "12s ago", "3m ago", "2h ago").
 export function formatRelativeTime(from: Date, now: Date = new Date()): string {
   const seconds = Math.round((now.getTime() - from.getTime()) / 1000);
-  if (seconds < 0) return 'just now';
+  // Covers future timestamps (negative) too.
   if (seconds < 5) return 'just now';
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary

Keeps the record list current without a manual page reload, implementing both phases of #23.

**Backend**
- `registry.Watch(ctx)` — a coalesced change signal backed by an etcd `Watch` on the configured `path_prefix`; the channel closes when the watch ends so the consumer can re-establish it.
- New `internal/stream` **Broker** — owns a *single* etcd watch and fans full record snapshots out to all connected clients (constant etcd cost regardless of how many browsers are open). Re-lists on each change and serves `GET /api/records/stream` as Server-Sent Events (`records` events + heartbeat comments), reconnecting the watch with capped exponential backoff.
- New Prometheus gauge `auto_dns_webui_stream_clients` for connected stream clients.
- Broker wired through `app`/`server` and run for the process lifetime.

**Frontend**
- `useRecords` hook — SSE-first live updates with a transparent **polling fallback** (when `EventSource` is unavailable or the stream fails), **pause-while-tab-hidden**, manual refresh, and last-updated tracking.
- `StatusBar` component — connection-status indicator, relative "updated X ago" time, and a **Refresh** button. `RecordList` now consumes the hook.

**Docs**
- README documents the stream endpoint, the SSE wire format, the polling fallback, and the new metric.
- CHANGELOG `## [Unreleased]` entry.

This is **purely additive** — no change to the existing public contract (`/api/records`, `AUTO_DNS_WEBUI_*`, MCP tool schemas) or to the consumed `docker-coredns-sync` etcd record schema (the stream reads the same records). A backward-compatible feature → targets the **v0.8.0** milestone.

## Linked issues

Closes #23

## Checklist

- [x] Branched off the target **milestone branch** (`vMAJOR.MINOR.PATCH`) and targets it (not `main`)
- [x] `make check` passes (lint + typecheck + test, backend and frontend) — ran the underlying `go vet`/`go test ./...` and `npm run typecheck`/`lint`/`test` plus prod build; all green
- [x] Updated `CHANGELOG.md` under `## [Unreleased]`
- [x] Noted any change to the minimum compatible `docker-coredns-sync` version (if the consumed etcd schema is affected) — unchanged; purely additive

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsTbzBTgGX7DYMQEMi8ZHo)_