### PR TITLE
Release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-29
+
 ### Added
 - Live record refresh. The record list now stays current without a manual page
   reload: the backend exposes a Server-Sent Events endpoint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,24 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+- Live record refresh. The record list now stays current without a manual page
+  reload: the backend exposes a Server-Sent Events endpoint
+  (`GET /api/records/stream`) backed by a single etcd `Watch` on the configured
+  `path_prefix`, fanning record snapshots out to all connected clients. The web
+  UI consumes the stream and falls back to polling `/api/records` when SSE is
+  unavailable (e.g. behind a buffering proxy), pausing updates while the tab is
+  hidden. A connection-status indicator, a "last updated" time, and a manual
+  **Refresh** control were added to the UI. New Prometheus gauge
+  `auto_dns_webui_stream_clients` reports the number of connected stream clients
+  (#23).
+
+### Notes
+- Purely additive: no change to the existing public contract (`/api/records`,
+  `AUTO_DNS_WEBUI_*` config, MCP tool schemas) or to the consumed
+  `docker-coredns-sync` etcd record schema — the new stream endpoint reads the
+  same records, so the minimum compatible producer version is unchanged.
+
 ## [0.7.0] - 2026-06-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ Versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - Live record refresh. The record list now stays current without a manual page
   reload: the backend exposes a Server-Sent Events endpoint
   (`GET /api/records/stream`) backed by a single etcd `Watch` on the configured
-  `path_prefix`, fanning record snapshots out to all connected clients. The web
-  UI consumes the stream and falls back to polling `/api/records` when SSE is
-  unavailable (e.g. behind a buffering proxy), pausing updates while the tab is
-  hidden. A connection-status indicator, a "last updated" time, and a manual
-  **Refresh** control were added to the UI. New Prometheus gauge
+  `path_prefix`, fanning record snapshots out to all connected clients, with a
+  periodic `ping` heartbeat event. The web UI consumes the stream and falls back
+  to polling `/api/records` when SSE is unavailable, errors, or opens but goes
+  silent (e.g. behind a buffering proxy — detected via a heartbeat watchdog),
+  pausing updates while the tab is hidden. A connection-status indicator, a
+  "last updated" time, and a manual **Refresh** control were added to the UI.
+  New Prometheus gauge
   `auto_dns_webui_stream_clients` reports the number of connected stream clients
   (#23).
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ data: [{"dnsRecord":{...},"metadata":{...}}, ...]
 
 ```
 
-Idle connections receive a `: ping` comment roughly every 25 seconds to keep proxies from dropping them. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable (e.g. behind a proxy that buffers responses).
+Idle connections receive a `ping` event roughly every 25 seconds to keep proxies from dropping them and to give clients a liveness signal. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable, errors, or opens but goes silent (e.g. behind a proxy that buffers responses) — if no `records` update or `ping` arrives within ~40 seconds the UI switches to polling.
 
 ### Health probes
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It optionally exposes an MCP (Model Context Protocol) server so AI tools like Cl
 
 - Browse all A/AAAA/CNAME records registered in etcd (SkyDNS format)
 - Filter by name, type, or source host
+- Live updates: the record list refreshes automatically as etcd changes (server-pushed over SSE, with polling fallback), plus a manual refresh and a "last updated" indicator
 - Optional MCP server: `list_dns_records`, `get_dns_record`, `get_records_by_host`
 
 ---
@@ -112,11 +113,26 @@ The HTTP server (`server.port`, default `8080`) exposes:
 |---|---|
 | `/` | The web UI (embedded SPA) |
 | `/api/records` | JSON list of all DNS records |
+| `/api/records/stream` | Server-Sent Events stream of record snapshots (see below) |
 | `/healthz` | Liveness — always `200 OK` while the process is serving. Does not touch etcd. |
 | `/readyz` | Readiness — `200 OK` when etcd is reachable, `503 Service Unavailable` otherwise (bounded by a short timeout). Use this as a container/orchestrator readiness probe. |
 | `/metrics` | Prometheus metrics (see below). |
 
 When the MCP server is enabled it also serves `/healthz` and `/readyz` on `mcp.port`, so the second server can be probed independently.
+
+### Live record stream
+
+`GET /api/records/stream` is a [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events) endpoint that keeps the UI current without manual reloads. The backend runs a single etcd `Watch` on the configured `path_prefix` and fans changes out to all connected clients, so the cost on etcd is constant regardless of how many browsers are open.
+
+On connect, and again whenever the record set changes, the server emits a `records` event whose `data` is the same JSON array returned by `/api/records`:
+
+```
+event: records
+data: [{"dnsRecord":{...},"metadata":{...}}, ...]
+
+```
+
+Idle connections receive a `: ping` comment roughly every 25 seconds to keep proxies from dropping them. The web UI consumes this stream automatically and transparently falls back to polling `/api/records` if the stream is unavailable (e.g. behind a proxy that buffers responses).
 
 ### Health probes
 
@@ -139,6 +155,7 @@ healthcheck:
 | `auto_dns_webui_http_requests_total` | counter | `route`, `method`, `code` | HTTP requests handled (API and health routes) |
 | `auto_dns_webui_http_request_duration_seconds` | histogram | `route`, `method` | HTTP request latency |
 | `auto_dns_webui_dns_records` | gauge | — | Records returned by the most recent successful etcd list |
+| `auto_dns_webui_stream_clients` | gauge | — | Currently connected record-stream (SSE) clients |
 | `auto_dns_webui_etcd_list_errors_total` | counter | — | Errors while listing records from etcd |
 | `auto_dns_webui_mcp_tool_calls_total` | counter | `tool` | MCP tool invocations by tool name |
 

--- a/backend/internal/api/handlers_test.go
+++ b/backend/internal/api/handlers_test.go
@@ -22,8 +22,11 @@ type mockRegistry struct {
 }
 
 func (m *mockRegistry) List(ctx context.Context) ([]*dns.Record, error) { return m.records, m.err }
-func (m *mockRegistry) Ping(ctx context.Context) error                  { return m.err }
-func (m *mockRegistry) Close() error                                    { return nil }
+func (m *mockRegistry) Watch(ctx context.Context) (<-chan struct{}, error) {
+	return nil, m.err
+}
+func (m *mockRegistry) Ping(ctx context.Context) error { return m.err }
+func (m *mockRegistry) Close() error                   { return nil }
 
 func TestRecords_Success(t *testing.T) {
 	reg := &mockRegistry{records: []*dns.Record{

--- a/backend/internal/app/app.go
+++ b/backend/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 	"github.com/auto-dns/auto-dns-webui/internal/metrics"
 	"github.com/auto-dns/auto-dns-webui/internal/registry"
 	"github.com/auto-dns/auto-dns-webui/internal/server"
+	"github.com/auto-dns/auto-dns-webui/internal/stream"
 	"github.com/rs/zerolog"
 	clientv3 "go.etcd.io/etcd/client/v3"
 )
@@ -20,6 +21,7 @@ import (
 type App struct {
 	Logger    zerolog.Logger
 	Server    httpServer
+	Broker    *stream.Broker
 	MCPServer *http.Server
 }
 
@@ -39,7 +41,7 @@ func NewHandler(r registry.Registry, m *metrics.Metrics, logger zerolog.Logger) 
 	return api.NewHandler(r, m, logger)
 }
 
-func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHandler *health.Handler, m *metrics.Metrics, logger zerolog.Logger) (httpServer, error) {
+func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHandler *health.Handler, m *metrics.Metrics, broker http.Handler, logger zerolog.Logger) (httpServer, error) {
 	mux := http.NewServeMux()
 
 	http := &http.Server{
@@ -47,7 +49,7 @@ func NewServer(cfg *config.ServerConfig, handler api.HandlerInterface, healthHan
 		Handler: mux,
 	}
 
-	return server.New(http, mux, handler, healthHandler, m, cfg, logger)
+	return server.New(http, mux, handler, healthHandler, m, broker, cfg, logger)
 }
 
 // New creates a new App by wiring up all dependencies.
@@ -60,8 +62,9 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	m := metrics.New()
 	handler := NewHandler(reg, m, logger)
 	healthHandler := health.New(reg, logger)
+	broker := stream.NewBroker(reg, m, logger)
 
-	srv, err := NewServer(&cfg.Server, handler, healthHandler, m, logger)
+	srv, err := NewServer(&cfg.Server, handler, healthHandler, m, broker, logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create server: %w", err)
 	}
@@ -91,6 +94,7 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 	return &App{
 		Logger:    logger,
 		Server:    srv,
+		Broker:    broker,
 		MCPServer: mcpHTTP,
 	}, nil
 }
@@ -98,6 +102,10 @@ func New(cfg *config.Config, logger zerolog.Logger) (*App, error) {
 // Run starts the application by running the sync engine.
 func (a *App) Run(ctx context.Context) error {
 	a.Logger.Info().Msg("Application starting")
+
+	if a.Broker != nil {
+		go a.Broker.Run(ctx)
+	}
 
 	if a.MCPServer != nil {
 		go func() {

--- a/backend/internal/metrics/metrics.go
+++ b/backend/internal/metrics/metrics.go
@@ -23,6 +23,7 @@ type Metrics struct {
 	httpDuration   *prometheus.HistogramVec
 	etcdListErrors prometheus.Counter
 	recordCount    prometheus.Gauge
+	streamClients  prometheus.Gauge
 	mcpToolCalls   *prometheus.CounterVec
 }
 
@@ -49,6 +50,10 @@ func New() *Metrics {
 			Name: "auto_dns_webui_dns_records",
 			Help: "Number of DNS records returned by the most recent successful etcd list.",
 		}),
+		streamClients: prometheus.NewGauge(prometheus.GaugeOpts{
+			Name: "auto_dns_webui_stream_clients",
+			Help: "Number of currently connected record-stream (SSE) clients.",
+		}),
 		mcpToolCalls: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "auto_dns_webui_mcp_tool_calls_total",
 			Help: "Total number of MCP tool invocations, by tool name.",
@@ -59,6 +64,7 @@ func New() *Metrics {
 		m.httpDuration,
 		m.etcdListErrors,
 		m.recordCount,
+		m.streamClients,
 		m.mcpToolCalls,
 		collectors.NewGoCollector(),
 		collectors.NewProcessCollector(collectors.ProcessCollectorOpts{}),
@@ -90,6 +96,12 @@ func (m *Metrics) SetRecordCount(n int) { m.recordCount.Set(float64(n)) }
 
 // RecordEtcdListError increments the etcd list-error counter.
 func (m *Metrics) RecordEtcdListError() { m.etcdListErrors.Inc() }
+
+// IncStreamClients records a newly connected record-stream client.
+func (m *Metrics) IncStreamClients() { m.streamClients.Inc() }
+
+// DecStreamClients records a disconnected record-stream client.
+func (m *Metrics) DecStreamClients() { m.streamClients.Dec() }
 
 // RecordMCPToolCall increments the call counter for the named MCP tool.
 func (m *Metrics) RecordMCPToolCall(tool string) { m.mcpToolCalls.WithLabelValues(tool).Inc() }

--- a/backend/internal/registry/etcd_registry.go
+++ b/backend/internal/registry/etcd_registry.go
@@ -17,6 +17,7 @@ import (
 // etcdClient is the subset of clientv3.Client this read-only app needs.
 type etcdClient interface {
 	Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 	Close() error
 }
 
@@ -109,6 +110,44 @@ func (er *EtcdRegistry) List(ctx context.Context) ([]*dns.Record, error) {
 		records = append(records, record)
 	}
 	return records, nil
+}
+
+// Watch establishes an etcd watch on the configured prefix and returns a
+// channel that emits a value whenever the record set under that prefix changes.
+// Notifications are coalesced: the channel has a buffer of one and a pending
+// notification is dropped rather than blocking, so a burst of etcd events
+// surfaces as a single "something changed" signal — consumers re-List to get
+// the current state. The channel is closed when the watch ends (ctx cancelled,
+// or the watch is cancelled/errors by etcd), which signals the consumer to
+// re-establish it.
+func (er *EtcdRegistry) Watch(ctx context.Context) (<-chan struct{}, error) {
+	wch := er.client.Watch(ctx, er.cfg.PathPrefix, clientv3.WithPrefix())
+	out := make(chan struct{}, 1)
+	go func() {
+		defer close(out)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case resp, ok := <-wch:
+				if !ok {
+					return
+				}
+				if err := resp.Err(); err != nil {
+					er.logger.Error().Err(err).Msg("etcd watch error")
+					return
+				}
+				if len(resp.Events) == 0 {
+					continue
+				}
+				select {
+				case out <- struct{}{}:
+				default:
+				}
+			}
+		}
+	}()
+	return out, nil
 }
 
 // Ping performs a cheap reachability check against etcd. It issues a bounded,

--- a/backend/internal/registry/etcd_registry_test.go
+++ b/backend/internal/registry/etcd_registry_test.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/rs/zerolog"
 	mvccpb "go.etcd.io/etcd/api/v3/mvccpb"
@@ -11,13 +12,19 @@ import (
 	"github.com/auto-dns/auto-dns-webui/internal/config"
 )
 
-// mockEtcdClient implements the etcdClient interface with an overridable Get.
+// mockEtcdClient implements the etcdClient interface with an overridable Get
+// and Watch.
 type mockEtcdClient struct {
-	getFunc func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	getFunc   func(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error)
+	watchFunc func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan
 }
 
 func (m *mockEtcdClient) Get(ctx context.Context, key string, opts ...clientv3.OpOption) (*clientv3.GetResponse, error) {
 	return m.getFunc(ctx, key, opts...)
+}
+
+func (m *mockEtcdClient) Watch(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+	return m.watchFunc(ctx, key, opts...)
 }
 
 func (m *mockEtcdClient) Close() error { return nil }
@@ -114,6 +121,85 @@ func TestList(t *testing.T) {
 		}
 		if _, err := newTestRegistry(client).List(context.Background()); err == nil {
 			t.Fatal("expected error to propagate from client.Get")
+		}
+	})
+}
+
+func TestWatch(t *testing.T) {
+	t.Run("emits a coalesced signal on change events and closes when the watch ends", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse, 1)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		out, err := newTestRegistry(client).Watch(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wch <- clientv3.WatchResponse{Events: []*clientv3.Event{{}}}
+		select {
+		case _, ok := <-out:
+			if !ok {
+				t.Fatal("channel closed; expected a change signal")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for change signal")
+		}
+
+		// Closing the upstream watch should close the returned channel.
+		close(wch)
+		select {
+		case _, ok := <-out:
+			if ok {
+				t.Fatal("expected channel to be closed after watch ended")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for channel close")
+		}
+	})
+
+	t.Run("ignores responses with no events", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse, 1)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		out, err := newTestRegistry(client).Watch(context.Background())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		wch <- clientv3.WatchResponse{} // no events
+		select {
+		case <-out:
+			t.Fatal("did not expect a signal for an empty watch response")
+		case <-time.After(50 * time.Millisecond):
+		}
+	})
+
+	t.Run("stops when context is cancelled", func(t *testing.T) {
+		wch := make(chan clientv3.WatchResponse)
+		client := &mockEtcdClient{
+			watchFunc: func(ctx context.Context, key string, opts ...clientv3.OpOption) clientv3.WatchChan {
+				return wch
+			},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		out, err := newTestRegistry(client).Watch(ctx)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		cancel()
+		select {
+		case _, ok := <-out:
+			if ok {
+				t.Fatal("expected channel to close after context cancel")
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for channel close after cancel")
 		}
 	})
 }

--- a/backend/internal/registry/registry.go
+++ b/backend/internal/registry/registry.go
@@ -8,6 +8,10 @@ import (
 
 type Registry interface {
 	List(ctx context.Context) ([]*dns.Record, error)
+	// Watch returns a channel that emits whenever the record set changes,
+	// allowing the record stream to push live updates. The channel is closed
+	// when the underlying watch ends and should be re-established by the caller.
+	Watch(ctx context.Context) (<-chan struct{}, error)
 	// Ping is a cheap reachability check against the backing store, used by the
 	// readiness probe.
 	Ping(ctx context.Context) error

--- a/backend/internal/server/server.go
+++ b/backend/internal/server/server.go
@@ -21,9 +21,10 @@ type Server struct {
 	handler api.HandlerInterface
 	health  *health.Handler
 	metrics *metrics.Metrics
+	stream  http.Handler
 }
 
-func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, health *health.Handler, metrics *metrics.Metrics, cfg *config.ServerConfig, logger zerolog.Logger) (*Server, error) {
+func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, health *health.Handler, metrics *metrics.Metrics, stream http.Handler, cfg *config.ServerConfig, logger zerolog.Logger) (*Server, error) {
 	s := &Server{
 		cfg:     cfg,
 		logger:  logger,
@@ -32,6 +33,7 @@ func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, he
 		handler: handler,
 		health:  health,
 		metrics: metrics,
+		stream:  stream,
 	}
 	if err := s.registerRoutes(); err != nil {
 		return nil, err
@@ -42,6 +44,14 @@ func New(http *http.Server, mux *http.ServeMux, handler api.HandlerInterface, he
 func (s *Server) registerRoutes() error {
 	// API routes (instrumented for request/latency metrics).
 	s.mux.Handle("/api/records", s.metrics.InstrumentHandler("/api/records", http.HandlerFunc(s.handler.Records)))
+
+	// Live record stream (SSE). Deliberately not wrapped in the latency
+	// histogram: these are long-lived connections, so a request-duration
+	// observation (recorded only on disconnect) would be meaningless. Connected
+	// clients are tracked by the stream gauge instead.
+	if s.stream != nil {
+		s.mux.Handle("/api/records/stream", s.stream)
+	}
 
 	// Operational endpoints.
 	s.mux.Handle("/healthz", s.metrics.InstrumentHandler("/healthz", http.HandlerFunc(s.health.Healthz)))

--- a/backend/internal/stream/broker.go
+++ b/backend/internal/stream/broker.go
@@ -1,0 +1,233 @@
+// Package stream pushes live DNS record updates to connected clients over
+// Server-Sent Events (SSE).
+//
+// A single Broker owns one etcd watch (via the registry) and fans changes out
+// to every connected client, so the cost on etcd is constant regardless of how
+// many browsers are watching. On each change the broker re-lists the full
+// record set and broadcasts it as a JSON snapshot identical in shape to
+// GET /api/records — clients simply replace their state, which keeps the wire
+// protocol and the frontend trivial.
+package stream
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+	"github.com/rs/zerolog"
+)
+
+// Source supplies the current record set and a change signal. *EtcdRegistry
+// satisfies it.
+type Source interface {
+	List(ctx context.Context) ([]*dns.Record, error)
+	Watch(ctx context.Context) (<-chan struct{}, error)
+}
+
+// Metrics is the subset of *metrics.Metrics the broker reports to.
+type Metrics interface {
+	IncStreamClients()
+	DecStreamClients()
+}
+
+const (
+	// heartbeatInterval bounds how long a stream can sit idle before the broker
+	// writes an SSE comment, keeping intermediary proxies from dropping it and
+	// letting the server notice a dead client.
+	heartbeatInterval = 25 * time.Second
+
+	// minBackoff/maxBackoff bound the retry delay when the etcd watch ends and
+	// must be re-established.
+	minBackoff = 1 * time.Second
+	maxBackoff = 30 * time.Second
+)
+
+// subscriber is one connected SSE client. ch carries pre-encoded snapshot
+// payloads; it is buffered with capacity one and coalesced so a slow client
+// only ever falls behind to the latest snapshot, never blocks the broker.
+type subscriber struct {
+	ch chan []byte
+}
+
+// Broker watches etcd and fans record snapshots out to SSE subscribers.
+type Broker struct {
+	source  Source
+	metrics Metrics
+	logger  zerolog.Logger
+
+	mu     sync.Mutex
+	subs   map[*subscriber]struct{}
+	latest []byte // most recent snapshot, replayed to new subscribers
+}
+
+// NewBroker creates a Broker. Call Run to start watching; register the Broker
+// as an http.Handler to serve the SSE endpoint.
+func NewBroker(source Source, metrics Metrics, logger zerolog.Logger) *Broker {
+	return &Broker{
+		source:  source,
+		metrics: metrics,
+		logger:  logger,
+		subs:    make(map[*subscriber]struct{}),
+	}
+}
+
+// Run drives the watch loop until ctx is cancelled, re-establishing the etcd
+// watch with capped exponential backoff whenever it ends.
+func (b *Broker) Run(ctx context.Context) {
+	backoff := minBackoff
+	for ctx.Err() == nil {
+		err := b.watchLoop(ctx)
+		if ctx.Err() != nil {
+			return
+		}
+		if err != nil {
+			b.logger.Error().Err(err).Dur("retry_in", backoff).Msg("record watch ended; retrying")
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-time.After(backoff):
+		}
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
+	}
+}
+
+// watchLoop establishes one watch, pushes an initial snapshot, and broadcasts a
+// fresh snapshot on every change until the watch ends or ctx is cancelled.
+func (b *Broker) watchLoop(ctx context.Context) error {
+	wch, err := b.source.Watch(ctx)
+	if err != nil {
+		return fmt.Errorf("establishing watch: %w", err)
+	}
+	// Snapshot current state so newly (re)connected clients are immediately
+	// up to date without waiting for the next etcd change.
+	b.refresh(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case _, ok := <-wch:
+			if !ok {
+				return errors.New("watch channel closed")
+			}
+			b.refresh(ctx)
+		}
+	}
+}
+
+// refresh lists the current records, encodes them, and broadcasts the snapshot
+// to all subscribers. List/encode failures are logged and skipped — the last
+// good snapshot stays in place.
+func (b *Broker) refresh(ctx context.Context) {
+	records, err := b.source.List(ctx)
+	if err != nil {
+		b.logger.Error().Err(err).Msg("failed to list records for stream update")
+		return
+	}
+	if records == nil {
+		records = []*dns.Record{}
+	}
+	data, err := json.Marshal(records)
+	if err != nil {
+		b.logger.Error().Err(err).Msg("failed to encode records for stream update")
+		return
+	}
+
+	b.mu.Lock()
+	b.latest = data
+	for s := range b.subs {
+		send(s.ch, data)
+	}
+	b.mu.Unlock()
+}
+
+// send delivers data to a capacity-one channel without blocking, replacing any
+// stale queued snapshot so the client always converges on the newest state.
+func send(ch chan []byte, data []byte) {
+	for {
+		select {
+		case ch <- data:
+			return
+		default:
+			select {
+			case <-ch:
+			default:
+			}
+		}
+	}
+}
+
+func (b *Broker) subscribe() *subscriber {
+	s := &subscriber{ch: make(chan []byte, 1)}
+	b.mu.Lock()
+	if b.latest != nil {
+		s.ch <- b.latest // safe: buffer cap 1, freshly created and empty
+	}
+	b.subs[s] = struct{}{}
+	b.mu.Unlock()
+	b.metrics.IncStreamClients()
+	return s
+}
+
+func (b *Broker) unsubscribe(s *subscriber) {
+	b.mu.Lock()
+	_, ok := b.subs[s]
+	delete(b.subs, s)
+	b.mu.Unlock()
+	if ok {
+		b.metrics.DecStreamClients()
+	}
+}
+
+// ServeHTTP implements the SSE endpoint: it holds the connection open and
+// writes a `records` event (current snapshot, then one per change) plus
+// periodic heartbeat comments until the client disconnects.
+func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	h := w.Header()
+	h.Set("Content-Type", "text/event-stream")
+	h.Set("Cache-Control", "no-cache")
+	h.Set("Connection", "keep-alive")
+	h.Set("X-Accel-Buffering", "no") // tell nginx not to buffer the stream
+	w.WriteHeader(http.StatusOK)
+	flusher.Flush()
+
+	sub := b.subscribe()
+	defer b.unsubscribe(sub)
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case data := <-sub.ch:
+			// Compact JSON never contains a newline, so a single data: line is
+			// a valid SSE frame.
+			if _, err := fmt.Fprintf(w, "event: records\ndata: %s\n\n", data); err != nil {
+				return
+			}
+			flusher.Flush()
+		case <-heartbeat.C:
+			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+				return
+			}
+			flusher.Flush()
+		}
+	}
+}

--- a/backend/internal/stream/broker.go
+++ b/backend/internal/stream/broker.go
@@ -189,7 +189,7 @@ func (b *Broker) unsubscribe(s *subscriber) {
 
 // ServeHTTP implements the SSE endpoint: it holds the connection open and
 // writes a `records` event (current snapshot, then one per change) plus
-// periodic heartbeat comments until the client disconnects.
+// periodic `ping` heartbeat events until the client disconnects.
 func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	flusher, ok := w.(http.Flusher)
 	if !ok {
@@ -224,7 +224,11 @@ func (b *Broker) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			}
 			flusher.Flush()
 		case <-heartbeat.C:
-			if _, err := fmt.Fprint(w, ": ping\n\n"); err != nil {
+			// A named `ping` event (rather than a bare comment) keeps proxies
+			// from dropping the connection *and* gives clients a visible
+			// liveness signal so they can tell an idle-but-healthy stream from a
+			// stalled one (EventSource does not surface comment lines to JS).
+			if _, err := fmt.Fprint(w, "event: ping\ndata: {}\n\n"); err != nil {
 				return
 			}
 			flusher.Flush()

--- a/backend/internal/stream/broker_test.go
+++ b/backend/internal/stream/broker_test.go
@@ -1,0 +1,184 @@
+package stream
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+
+	"github.com/auto-dns/auto-dns-webui/internal/dns"
+)
+
+// fakeSource is a controllable Source for broker tests.
+type fakeSource struct {
+	mu      sync.Mutex
+	records []*dns.Record
+	watchCh chan struct{}
+	listed  chan struct{} // signalled after each List call (best-effort)
+}
+
+func (f *fakeSource) setRecords(recs []*dns.Record) {
+	f.mu.Lock()
+	f.records = recs
+	f.mu.Unlock()
+}
+
+func (f *fakeSource) List(ctx context.Context) ([]*dns.Record, error) {
+	f.mu.Lock()
+	recs := f.records
+	f.mu.Unlock()
+	if f.listed != nil {
+		select {
+		case f.listed <- struct{}{}:
+		default:
+		}
+	}
+	return recs, nil
+}
+
+func (f *fakeSource) Watch(ctx context.Context) (<-chan struct{}, error) {
+	return f.watchCh, nil
+}
+
+type fakeMetrics struct {
+	mu  sync.Mutex
+	cur int
+}
+
+func (m *fakeMetrics) IncStreamClients() {
+	m.mu.Lock()
+	m.cur++
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) DecStreamClients() {
+	m.mu.Lock()
+	m.cur--
+	m.mu.Unlock()
+}
+
+func (m *fakeMetrics) count() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.cur
+}
+
+func rec(name string) *dns.Record {
+	return &dns.Record{Dns: dns.DnsRecord{Name: name, Type: "A", Value: "10.0.0.1"}}
+}
+
+// readEvent reads one SSE frame (skipping heartbeat comments) and returns the
+// event name and the data payload.
+func readEvent(t *testing.T, r *bufio.Reader) (event, data string) {
+	t.Helper()
+	for {
+		line, err := r.ReadString('\n')
+		if err != nil {
+			t.Fatalf("reading stream: %v", err)
+		}
+		line = strings.TrimRight(line, "\n")
+		switch {
+		case strings.HasPrefix(line, ":"):
+			continue // heartbeat comment
+		case strings.HasPrefix(line, "event:"):
+			event = strings.TrimSpace(strings.TrimPrefix(line, "event:"))
+		case strings.HasPrefix(line, "data:"):
+			data = strings.TrimSpace(strings.TrimPrefix(line, "data:"))
+		case line == "":
+			if event != "" || data != "" {
+				return event, data
+			}
+		}
+	}
+}
+
+func TestBrokerServeHTTP(t *testing.T) {
+	src := &fakeSource{records: []*dns.Record{rec("app.example.com")}, watchCh: make(chan struct{}, 1)}
+	m := &fakeMetrics{}
+	b := NewBroker(src, m, zerolog.Nop())
+
+	// Populate the latest snapshot so a freshly connected client receives it.
+	b.refresh(context.Background())
+
+	srv := httptest.NewServer(b)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL)
+	if err != nil {
+		t.Fatalf("connecting: %v", err)
+	}
+	defer resp.Body.Close()
+	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
+		t.Fatalf("content-type = %q, want text/event-stream", ct)
+	}
+
+	r := bufio.NewReader(resp.Body)
+
+	// Initial snapshot replay.
+	event, data := readEvent(t, r)
+	if event != "records" {
+		t.Fatalf("event = %q, want records", event)
+	}
+	if !strings.Contains(data, "app.example.com") {
+		t.Fatalf("initial snapshot missing record: %s", data)
+	}
+
+	// A change broadcasts a fresh snapshot.
+	src.setRecords([]*dns.Record{rec("db.example.com")})
+	b.refresh(context.Background())
+	event, data = readEvent(t, r)
+	if event != "records" || !strings.Contains(data, "db.example.com") {
+		t.Fatalf("update snapshot wrong: event=%q data=%s", event, data)
+	}
+
+	// Client is counted while connected.
+	if got := m.count(); got != 1 {
+		t.Fatalf("stream client count = %d, want 1", got)
+	}
+
+	resp.Body.Close()
+	deadline := time.Now().Add(2 * time.Second)
+	for m.count() != 0 {
+		if time.Now().After(deadline) {
+			t.Fatalf("stream client count = %d after disconnect, want 0", m.count())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestBrokerRunRefreshesOnWatch(t *testing.T) {
+	src := &fakeSource{
+		records: []*dns.Record{rec("app.example.com")},
+		watchCh: make(chan struct{}, 1),
+		listed:  make(chan struct{}, 8),
+	}
+	b := NewBroker(src, &fakeMetrics{}, zerolog.Nop())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go b.Run(ctx)
+
+	// Initial refresh on watch establishment.
+	waitListed(t, src.listed, "initial refresh")
+
+	// A watch signal triggers another List.
+	src.watchCh <- struct{}{}
+	waitListed(t, src.listed, "refresh on change")
+
+	cancel()
+}
+
+func waitListed(t *testing.T, listed chan struct{}, what string) {
+	t.Helper()
+	select {
+	case <-listed:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for List (%s)", what)
+	}
+}

--- a/backend/internal/stream/broker_test.go
+++ b/backend/internal/stream/broker_test.go
@@ -113,7 +113,7 @@ func TestBrokerServeHTTP(t *testing.T) {
 	if err != nil {
 		t.Fatalf("connecting: %v", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 	if ct := resp.Header.Get("Content-Type"); ct != "text/event-stream" {
 		t.Fatalf("content-type = %q, want text/event-stream", ct)
 	}
@@ -142,7 +142,7 @@ func TestBrokerServeHTTP(t *testing.T) {
 		t.Fatalf("stream client count = %d, want 1", got)
 	}
 
-	resp.Body.Close()
+	_ = resp.Body.Close()
 	deadline := time.Now().Add(2 * time.Second)
 	for m.count() != 0 {
 		if time.Now().After(deadline) {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,7 @@
         "eslint": "^9.28.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
-        "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "globals": "^17.7.0",
         "prettier": "^3.8.5",
         "sass-embedded": "^1.100.0",
@@ -32,6 +32,246 @@
         "typescript-eslint": "^8.62.0",
         "vite": "^8.1.0",
         "vitest": "^4.1.9"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@bufbuild/protobuf": {
@@ -361,12 +601,55 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "1.1.6",
@@ -1721,6 +2004,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -1730,6 +2026,40 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
     "node_modules/call-bind": {
@@ -1791,6 +2121,27 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/chai": {
       "version": "6.2.2",
@@ -2058,6 +2409,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.379",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.379.tgz",
+      "integrity": "sha512-v/qV5aV5EUA2pGilzUCq5/eyOloZAqDZBu9UMBIzgPpLlprjSR6zswsWBTv0KpqxLGUAZEwhO95ZCt7srymNVA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/es-abstract": {
       "version": "1.24.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
@@ -2242,6 +2600,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -2366,16 +2734,23 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {
@@ -2667,6 +3042,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2872,6 +3257,23 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/ignore": {
@@ -3366,6 +3768,19 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3386,6 +3801,19 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
@@ -3724,6 +4152,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.21.0.tgz",
@@ -3806,6 +4244,16 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -5346,6 +5794,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -5663,6 +6142,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -5674,6 +6160,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     }
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -21,7 +21,7 @@
         "@types/node": "^26.0.1",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "eslint": "^9.28.0",
+        "eslint": "^9.39.4",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
@@ -171,34 +171,37 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
-      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.6",
+        "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.2.2.tgz",
-      "integrity": "sha512-+GPzk8PlG0sPpzdU5ZvIRMPidzAnZDl/s9L+y13iodqvb8leL53bTannOrQ/Im7UkpsmFU5Ily5U60LWixnmLg==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@eslint/core": "^0.17.0"
+      },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-      "integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -209,20 +212,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -259,9 +262,9 @@
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-      "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
@@ -269,27 +272,14 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
-      "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.15.2",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-      "version": "0.15.2",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
-      "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@types/json-schema": "^7.0.15"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1478,9 +1468,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.15.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-      "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "version": "8.17.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -2256,33 +2246,32 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.28.0.tgz",
-      "integrity": "sha512-ocgh41VhRlf9+fVpe7QKzwLj9c92fDiqOj8Y3Sd4/ZmVA4Btx4PlUYPq4pp9JDyupkf1upbEXecxL2mwNV7jPQ==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
+        "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.20.0",
-        "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.14.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.28.0",
-        "@eslint/plugin-kit": "^0.3.1",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "@types/json-schema": "^7.0.15",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.3.0",
-        "eslint-visitor-keys": "^4.2.0",
-        "espree": "^10.3.0",
+        "eslint-scope": "^8.4.0",
+        "eslint-visitor-keys": "^4.2.1",
+        "espree": "^10.4.0",
         "esquery": "^1.5.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
@@ -2294,7 +2283,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2406,19 +2395,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.28.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.28.0.tgz",
-      "integrity": "sha512-fnqSjGWd/CoIp4EXIxWVK/sHA6DOHN4+8Ix2cX5ycOY7LG0UY8nHCU5pIp2eaE1Mc7Qd8kHspYNzYXT2ojPLzg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {
@@ -3354,10 +3330,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -18,7 +18,7 @@
     "@types/node": "^26.0.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "eslint": "^9.28.0",
+    "eslint": "^9.39.4",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,7 @@
     "eslint": "^9.28.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
-    "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "globals": "^17.7.0",
     "prettier": "^3.8.5",
     "sass-embedded": "^1.100.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auto-dns-webui",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src/components/StatusBar/StatusBar.module.scss
+++ b/frontend/src/components/StatusBar/StatusBar.module.scss
@@ -1,0 +1,62 @@
+@use '../../styles/variables' as *;
+
+.statusBar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 0.5rem 1rem;
+  margin: 0 0 1rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.indicator {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-weight: 500;
+}
+
+.dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background-color: var(--text-muted);
+}
+
+.live {
+  color: #1a8f4a;
+
+  .dot {
+    background-color: #1fb05a;
+    box-shadow: 0 0 0 3px rgba(31, 176, 90, 0.2);
+  }
+}
+
+.polling .dot,
+.connecting .dot {
+  background-color: #d9a200;
+  box-shadow: 0 0 0 3px rgba(217, 162, 0, 0.2);
+}
+
+.updated {
+  white-space: nowrap;
+}
+
+.refresh {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  font-size: 0.85rem;
+  color: var(--text-color);
+  background-color: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  cursor: pointer;
+
+  &:hover {
+    background-color: var(--card-border);
+  }
+}

--- a/frontend/src/components/StatusBar/StatusBar.tsx
+++ b/frontend/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import classNames from 'classnames';
+import { ConnectionStatus } from '../../hooks/useRecords';
+import { formatRelativeTime } from '../../utils/time';
+import styles from './StatusBar.module.scss';
+
+interface StatusBarProps {
+  status: ConnectionStatus;
+  lastUpdated: Date | null;
+  onRefresh: () => void;
+}
+
+const STATUS_LABEL: Record<ConnectionStatus, string> = {
+  connecting: 'Connecting…',
+  live: 'Live',
+  polling: 'Polling',
+};
+
+// How often the relative "updated Xs ago" label is recomputed.
+const TICK_MS = 10_000;
+
+export default function StatusBar({ status, lastUpdated, onRefresh }: StatusBarProps) {
+  // Re-render periodically so the relative timestamp stays current even when
+  // no new data has arrived.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), TICK_MS);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div className={styles.statusBar}>
+      <span
+        className={classNames(styles.indicator, styles[status])}
+        role="status"
+        aria-live="polite"
+        title={`Updates: ${STATUS_LABEL[status]}`}
+      >
+        <span className={styles.dot} aria-hidden="true" />
+        {STATUS_LABEL[status]}
+      </span>
+      {lastUpdated && (
+        <span className={styles.updated} title={lastUpdated.toLocaleString()}>
+          Updated {formatRelativeTime(lastUpdated)}
+        </span>
+      )}
+      <button
+        className={styles.refresh}
+        onClick={onRefresh}
+        aria-label="Refresh records"
+        title="Refresh records"
+      >
+        <RefreshCw size={16} />
+        Refresh
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/hooks/useRecords.ts
+++ b/frontend/src/hooks/useRecords.ts
@@ -10,6 +10,12 @@ export type ConnectionStatus = 'connecting' | 'live' | 'polling';
 // How often the polling fallback re-fetches when the live stream is down.
 const POLL_INTERVAL_MS = 15_000;
 
+// If the open stream delivers nothing (no `records` update and no `ping`
+// heartbeat) within this window, treat it as stalled and fall back to polling.
+// Must exceed the server's heartbeat interval (25s) with margin so a healthy but
+// idle stream is never mistaken for a dead one.
+const STALL_TIMEOUT_MS = 40_000;
+
 export interface UseRecordsResult {
   records: RecordEntry[];
   loading: boolean;
@@ -21,8 +27,9 @@ export interface UseRecordsResult {
 
 // useRecords loads the DNS record set and keeps it live. It prefers a
 // server-pushed SSE stream (`/api/records/stream`) and transparently falls back
-// to interval polling of `/api/records` when EventSource is unavailable or the
-// stream fails. Updates pause while the tab is hidden and catch up on return.
+// to interval polling of `/api/records` when EventSource is unavailable, the
+// stream errors, or the stream opens but goes silent (e.g. behind a buffering
+// proxy). Updates pause while the tab is hidden and catch up on return.
 export function useRecords(): UseRecordsResult {
   const [records, setRecords] = useState<RecordEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -32,6 +39,7 @@ export function useRecords(): UseRecordsResult {
 
   const esRef = useRef<EventSource | null>(null);
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const stallRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // Apply a fresh snapshot from any source (fetch or stream).
   const applySnapshot = useCallback((data: RecordEntry[]) => {
@@ -78,6 +86,9 @@ export function useRecords(): UseRecordsResult {
   const startPolling = useCallback(() => {
     if (pollRef.current !== null) return;
     setStatus('polling');
+    // Fetch immediately so the list catches up without waiting a full interval;
+    // the interval handles subsequent refreshes (skipped while the tab is hidden).
+    void fetchRecords(false);
     pollRef.current = setInterval(() => {
       if (!document.hidden) {
         void fetchRecords(false);
@@ -85,7 +96,17 @@ export function useRecords(): UseRecordsResult {
     }, POLL_INTERVAL_MS);
   }, [fetchRecords]);
 
-  // (Re)open the SSE stream, falling back to polling if it can't be used.
+  const clearStall = useCallback(() => {
+    if (stallRef.current !== null) {
+      clearTimeout(stallRef.current);
+      stallRef.current = null;
+    }
+  }, []);
+
+  // (Re)open the SSE stream, falling back to polling if it can't be used. The
+  // stream is only considered "live" once it actually delivers something, so a
+  // connection that opens but stays silent falls back via the stall watchdog
+  // while polling keeps the data fresh in the meantime.
   const connect = useCallback(() => {
     if (typeof EventSource === 'undefined') {
       startPolling();
@@ -97,9 +118,27 @@ export function useRecords(): UseRecordsResult {
     const es = new EventSource('/api/records/stream');
     esRef.current = es;
 
-    es.addEventListener('records', (ev) => {
-      stopPolling();
+    // Re-arm the stall watchdog: if nothing arrives within the timeout, the
+    // stream is treated as dead and we fall back to polling.
+    const armStall = () => {
+      clearStall();
+      stallRef.current = setTimeout(() => {
+        esRef.current?.close();
+        esRef.current = null;
+        startPolling();
+      }, STALL_TIMEOUT_MS);
+    };
+
+    // Any traffic (a snapshot or a heartbeat) proves the stream is flowing:
+    // mark it live, stop the polling fallback, and reset the watchdog.
+    const onTraffic = () => {
       setStatus('live');
+      stopPolling();
+      armStall();
+    };
+
+    es.addEventListener('records', (ev) => {
+      onTraffic();
       try {
         const data = JSON.parse((ev as MessageEvent).data) as RecordEntry[];
         applySnapshot(data);
@@ -108,21 +147,21 @@ export function useRecords(): UseRecordsResult {
       }
     });
 
-    es.onopen = () => {
-      stopPolling();
-      setStatus('live');
-    };
+    es.addEventListener('ping', onTraffic);
 
     es.onerror = () => {
       // EventSource retries on its own while readyState === CONNECTING; only a
-      // fully closed stream means we should fall back to polling.
+      // fully closed stream means we should fall back to polling immediately.
       if (es.readyState === EventSource.CLOSED) {
+        clearStall();
         startPolling();
       } else {
         setStatus('connecting');
       }
     };
-  }, [applySnapshot, startPolling, stopPolling]);
+
+    armStall();
+  }, [applySnapshot, clearStall, startPolling, stopPolling]);
 
   // Manual refresh: immediate fetch regardless of the active transport.
   const refresh = useCallback(() => {
@@ -137,6 +176,7 @@ export function useRecords(): UseRecordsResult {
       esRef.current?.close();
       esRef.current = null;
       stopPolling();
+      clearStall();
     };
     // Run once on mount; the callbacks are stable for the component's lifetime.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -149,14 +189,16 @@ export function useRecords(): UseRecordsResult {
         esRef.current?.close();
         esRef.current = null;
         stopPolling();
+        clearStall();
       } else {
-        void fetchRecords(false);
+        // connect() replays the current snapshot over SSE (or starts polling,
+        // which fetches immediately), so no separate catch-up fetch is needed.
         connect();
       }
     };
     document.addEventListener('visibilitychange', onVisibility);
     return () => document.removeEventListener('visibilitychange', onVisibility);
-  }, [connect, fetchRecords, stopPolling]);
+  }, [connect, clearStall, stopPolling]);
 
   return { records, loading, error, lastUpdated, status, refresh };
 }

--- a/frontend/src/hooks/useRecords.ts
+++ b/frontend/src/hooks/useRecords.ts
@@ -1,0 +1,162 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { RecordEntry } from '../types';
+
+// Connection status surfaced to the UI:
+// - 'connecting': the live stream is being (re)established
+// - 'live':       receiving server-pushed updates over SSE
+// - 'polling':    SSE is unavailable; falling back to interval polling
+export type ConnectionStatus = 'connecting' | 'live' | 'polling';
+
+// How often the polling fallback re-fetches when the live stream is down.
+const POLL_INTERVAL_MS = 15_000;
+
+export interface UseRecordsResult {
+  records: RecordEntry[];
+  loading: boolean;
+  error: string | null;
+  lastUpdated: Date | null;
+  status: ConnectionStatus;
+  refresh: () => void;
+}
+
+// useRecords loads the DNS record set and keeps it live. It prefers a
+// server-pushed SSE stream (`/api/records/stream`) and transparently falls back
+// to interval polling of `/api/records` when EventSource is unavailable or the
+// stream fails. Updates pause while the tab is hidden and catch up on return.
+export function useRecords(): UseRecordsResult {
+  const [records, setRecords] = useState<RecordEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [status, setStatus] = useState<ConnectionStatus>('connecting');
+
+  const esRef = useRef<EventSource | null>(null);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Apply a fresh snapshot from any source (fetch or stream).
+  const applySnapshot = useCallback((data: RecordEntry[]) => {
+    setRecords(data);
+    setLastUpdated(new Date());
+    setError(null);
+    setLoading(false);
+  }, []);
+
+  // One-shot fetch of the full record set. `showLoading` drives the page-level
+  // loading/error states (initial load and manual refresh); background polling
+  // passes false so a transient blip doesn't blank the list.
+  const fetchRecords = useCallback(
+    async (showLoading: boolean) => {
+      if (showLoading) {
+        setLoading(true);
+        setError(null);
+      }
+      try {
+        const res = await fetch('/api/records');
+        if (!res.ok) {
+          throw new Error(`Request failed: ${res.status} ${res.statusText}`);
+        }
+        const data = (await res.json()) as RecordEntry[];
+        applySnapshot(data);
+      } catch (err) {
+        console.error('Failed to fetch records:', err);
+        if (showLoading) {
+          setError('Failed to load DNS records. Please try again.');
+          setLoading(false);
+        }
+      }
+    },
+    [applySnapshot],
+  );
+
+  const stopPolling = useCallback(() => {
+    if (pollRef.current !== null) {
+      clearInterval(pollRef.current);
+      pollRef.current = null;
+    }
+  }, []);
+
+  const startPolling = useCallback(() => {
+    if (pollRef.current !== null) return;
+    setStatus('polling');
+    pollRef.current = setInterval(() => {
+      if (!document.hidden) {
+        void fetchRecords(false);
+      }
+    }, POLL_INTERVAL_MS);
+  }, [fetchRecords]);
+
+  // (Re)open the SSE stream, falling back to polling if it can't be used.
+  const connect = useCallback(() => {
+    if (typeof EventSource === 'undefined') {
+      startPolling();
+      return;
+    }
+    esRef.current?.close();
+    setStatus('connecting');
+
+    const es = new EventSource('/api/records/stream');
+    esRef.current = es;
+
+    es.addEventListener('records', (ev) => {
+      stopPolling();
+      setStatus('live');
+      try {
+        const data = JSON.parse((ev as MessageEvent).data) as RecordEntry[];
+        applySnapshot(data);
+      } catch (err) {
+        console.error('Failed to parse stream payload:', err);
+      }
+    });
+
+    es.onopen = () => {
+      stopPolling();
+      setStatus('live');
+    };
+
+    es.onerror = () => {
+      // EventSource retries on its own while readyState === CONNECTING; only a
+      // fully closed stream means we should fall back to polling.
+      if (es.readyState === EventSource.CLOSED) {
+        startPolling();
+      } else {
+        setStatus('connecting');
+      }
+    };
+  }, [applySnapshot, startPolling, stopPolling]);
+
+  // Manual refresh: immediate fetch regardless of the active transport.
+  const refresh = useCallback(() => {
+    void fetchRecords(true);
+  }, [fetchRecords]);
+
+  // Initial load + stream setup.
+  useEffect(() => {
+    void fetchRecords(true);
+    connect();
+    return () => {
+      esRef.current?.close();
+      esRef.current = null;
+      stopPolling();
+    };
+    // Run once on mount; the callbacks are stable for the component's lifetime.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Pause while the tab is hidden; resume and catch up when it becomes visible.
+  useEffect(() => {
+    const onVisibility = () => {
+      if (document.hidden) {
+        esRef.current?.close();
+        esRef.current = null;
+        stopPolling();
+      } else {
+        void fetchRecords(false);
+        connect();
+      }
+    };
+    document.addEventListener('visibilitychange', onVisibility);
+    return () => document.removeEventListener('visibilitychange', onVisibility);
+  }, [connect, fetchRecords, stopPolling]);
+
+  return { records, loading, error, lastUpdated, status, refresh };
+}

--- a/frontend/src/pages/RecordList/RecordList.tsx
+++ b/frontend/src/pages/RecordList/RecordList.tsx
@@ -1,18 +1,19 @@
 import { useMemo, useState, useEffect, useCallback, useRef } from 'react';
-import { Filters, RecordEntry, SortState } from '../../types';
+import { Filters, SortState } from '../../types';
 import { deriveFilterOptions } from '../../utils/filters';
 import SearchBar from '../../components/SearchBar/SearchBar';
 import FilterSortDrawer from '../../components/FilterSortDrawer/FilterSortDrawer';
 import RecordGrid from '../../components/RecordGrid/RecordGrid';
+import StatusBar from '../../components/StatusBar/StatusBar';
 import { SORT_KEYS, sortRecords } from '../../utils/sort';
 import { enrichSearchable } from '../../utils/record';
 import { filterRecords, getFacetCounts } from '../../utils/filters';
 import { parseFromUrl, updateUrl } from '../../utils/url';
 import { useSidebarState } from '../../hooks/useSidebarState';
+import { useRecords } from '../../hooks/useRecords';
 import styles from './RecordList.module.scss';
 import classNames from 'classnames';
 import { PanelLeft } from 'lucide-react';
-
 
 export default function RecordList() {
   // Initialize state from URL on mount
@@ -37,46 +38,18 @@ export default function RecordList() {
   }, []);
 
   // Declare state
-  const [records, setRecords] = useState<RecordEntry[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const { records, loading, error, lastUpdated, status, refresh } = useRecords();
   const [showSidebar, setShowSidebar] = useSidebarState();
   const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
   const [search, setSearch] = useState(initialState.search);
   const [filters, setFilters] = useState<Filters>(initialState.filters);
   const [sort, setSort] = useState<SortState>(initialState.sort);
   const [scrolled, setScrolled] = useState(false);
-  
+
   // Track if we should update URL (to avoid infinite loops during initialization)
   const isInitializing = useRef(true);
 
-  // Fetch records (retryable)
-  const loadRecords = useCallback(() => {
-    setLoading(true);
-    setError(null);
-    fetch('/api/records')
-      .then((res) => {
-        if (!res.ok) {
-          throw new Error(`Request failed: ${res.status} ${res.statusText}`);
-        }
-        return res.json();
-      })
-      .then((data: RecordEntry[]) => {
-        setRecords(data);
-        setLoading(false);
-      })
-      .catch((err) => {
-        console.error('Failed to fetch records:', err);
-        setError('Failed to load DNS records. Please try again.');
-        setLoading(false);
-      });
-  }, []);
-
   // Use effects
-  useEffect(() => {
-    loadRecords();
-  }, [loadRecords]);
-
   useEffect(() => {
     const onScroll = () => {
       setScrolled(window.scrollY > 0);
@@ -113,14 +86,23 @@ export default function RecordList() {
 
   // Memoize aggregated data
   const enrichedRecords = useMemo(() => enrichSearchable(records), [records]);
-  const filteredRecords = useMemo(() => filterRecords(enrichedRecords, filters, search), [enrichedRecords, filters, search]);
+  const filteredRecords = useMemo(
+    () => filterRecords(enrichedRecords, filters, search),
+    [enrichedRecords, filters, search],
+  );
   const sortedRecords = useMemo(() => sortRecords(filteredRecords, sort), [filteredRecords, sort]);
-  const facetCounts = useMemo(() => getFacetCounts(filteredRecords, filters), [filteredRecords, filters]);
-  const {recordTypes, recordValues, hostnames, forceValues} = useMemo(() => deriveFilterOptions(records), [records]);
+  const facetCounts = useMemo(
+    () => getFacetCounts(filteredRecords, filters),
+    [filteredRecords, filters],
+  );
+  const { recordTypes, recordValues, hostnames, forceValues } = useMemo(
+    () => deriveFilterOptions(records),
+    [records],
+  );
 
   // Set callbacks
   const toggleExpand = useCallback((key: string) => {
-    setExpandedKeys(prev => {
+    setExpandedKeys((prev) => {
       const updated = new Set(prev);
       updated.has(key) ? updated.delete(key) : updated.add(key);
       return updated;
@@ -164,8 +146,8 @@ export default function RecordList() {
             {!showSidebar && (
               <button
                 className={styles.hamburger}
-                onClick={() => setShowSidebar(s => !s)}
-                aria-label='Toggle filters'
+                onClick={() => setShowSidebar((s) => !s)}
+                aria-label="Toggle filters"
               >
                 <PanelLeft size={20} />
               </button>
@@ -176,14 +158,17 @@ export default function RecordList() {
           </div>
         </header>
         <h2 className={styles.pageTitle}>DNS Records</h2>
+        {!loading && !error && (
+          <StatusBar status={status} lastUpdated={lastUpdated} onRefresh={refresh} />
+        )}
         {loading ? (
-          <div className={styles.statusMessage} role='status' aria-live='polite'>
+          <div className={styles.statusMessage} role="status" aria-live="polite">
             Loading records…
           </div>
         ) : error ? (
-          <div className={styles.statusMessage} role='alert'>
+          <div className={styles.statusMessage} role="alert">
             <p>{error}</p>
-            <button className={styles.retryButton} onClick={loadRecords}>
+            <button className={styles.retryButton} onClick={refresh}>
               Retry
             </button>
           </div>

--- a/frontend/src/pages/RecordList/RecordList.tsx
+++ b/frontend/src/pages/RecordList/RecordList.tsx
@@ -44,19 +44,9 @@ export default function RecordList() {
   const [search, setSearch] = useState(initialState.search);
   const [filters, setFilters] = useState<Filters>(initialState.filters);
   const [sort, setSort] = useState<SortState>(initialState.sort);
-  const [scrolled, setScrolled] = useState(false);
 
   // Track if we should update URL (to avoid infinite loops during initialization)
   const isInitializing = useRef(true);
-
-  // Use effects
-  useEffect(() => {
-    const onScroll = () => {
-      setScrolled(window.scrollY > 0);
-    };
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   // Mark initialization as complete after first render
   useEffect(() => {

--- a/frontend/src/utils/time.test.ts
+++ b/frontend/src/utils/time.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { formatRelativeTime } from './time';
+
+describe('formatRelativeTime', () => {
+  const base = new Date('2026-06-26T12:00:00Z');
+
+  const at = (secondsAgo: number) => new Date(base.getTime() - secondsAgo * 1000);
+
+  it('renders "just now" for very recent times', () => {
+    expect(formatRelativeTime(at(0), base)).toBe('just now');
+    expect(formatRelativeTime(at(4), base)).toBe('just now');
+  });
+
+  it('renders seconds', () => {
+    expect(formatRelativeTime(at(5), base)).toBe('5s ago');
+    expect(formatRelativeTime(at(59), base)).toBe('59s ago');
+  });
+
+  it('renders minutes', () => {
+    expect(formatRelativeTime(at(60), base)).toBe('1m ago');
+    expect(formatRelativeTime(at(59 * 60), base)).toBe('59m ago');
+  });
+
+  it('renders hours', () => {
+    expect(formatRelativeTime(at(60 * 60), base)).toBe('1h ago');
+    expect(formatRelativeTime(at(23 * 60 * 60), base)).toBe('23h ago');
+  });
+
+  it('renders days', () => {
+    expect(formatRelativeTime(at(24 * 60 * 60), base)).toBe('1d ago');
+  });
+
+  it('treats future timestamps as "just now"', () => {
+    expect(formatRelativeTime(at(-10), base)).toBe('just now');
+  });
+});

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -1,0 +1,14 @@
+// formatRelativeTime renders a short, human-friendly "time ago" string for the
+// last-updated indicator (e.g. "just now", "12s ago", "3m ago", "2h ago").
+export function formatRelativeTime(from: Date, now: Date = new Date()): string {
+  const seconds = Math.round((now.getTime() - from.getTime()) / 1000);
+  if (seconds < 0) return 'just now';
+  if (seconds < 5) return 'just now';
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}

--- a/frontend/src/utils/time.ts
+++ b/frontend/src/utils/time.ts
@@ -2,7 +2,7 @@
 // last-updated indicator (e.g. "just now", "12s ago", "3m ago", "2h ago").
 export function formatRelativeTime(from: Date, now: Date = new Date()): string {
   const seconds = Math.round((now.getTime() - from.getTime()) / 1000);
-  if (seconds < 0) return 'just now';
+  // Covers future timestamps (negative) too.
   if (seconds < 5) return 'just now';
   if (seconds < 60) return `${seconds}s ago`;
   const minutes = Math.floor(seconds / 60);


### PR DESCRIPTION
## Summary

Integrates the **v0.8.0** milestone into `main` and prepares the release tag.

**Feature**
- **Live record refresh (#23)** — the record list stays current without a manual reload. New SSE endpoint `GET /api/records/stream` backed by a single etcd `Watch` fans record snapshots (plus `ping` heartbeats) out to all connected clients; the web UI consumes it and transparently falls back to polling `/api/records` when the stream is unavailable, errors, or opens but goes silent (heartbeat watchdog), pausing while the tab is hidden. Adds a connection-status indicator, a "last updated" time, a manual **Refresh** control, and a `auto_dns_webui_stream_clients` Prometheus gauge.

**Dependencies** (security updates, merged into the milestone)
- `eslint` 9.28.0 → 9.39.4 (#56)
- `eslint-plugin-react-hooks` 5.2.0 → 7.1.1 (#57)

**Release prep**
- CHANGELOG `## [Unreleased]` → `## [0.8.0] - 2026-06-29`
- `frontend/package.json` 0.7.0 → 0.8.0

Purely additive: no change to the public contract (`/api/records`, `AUTO_DNS_WEBUI_*` config, MCP tool schemas) or to the consumed `docker-coredns-sync` etcd record schema — the stream reads the same records, so the minimum compatible producer version is unchanged.

## Linked issues

Closes #23

## Checklist

- [x] This is the **milestone branch → `main`** merge (the documented exception to the "branch off the milestone branch" rule)
- [x] `make check` passes — backend `go vet`/`go test ./...`, frontend `lint`/`typecheck`/`build`; `npm ci` validated against the merged lockfile
- [x] `CHANGELOG.md` updated and the `## [0.8.0]` heading dated
- [x] No change to the minimum compatible `docker-coredns-sync` version (purely additive)

After merge: tag `v0.8.0` on `main` to trigger the GHCR image build and the GitHub Release cut from the `## [0.8.0]` CHANGELOG section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01EsTbzBTgGX7DYMQEMi8ZHo)_