### PR TITLE
fix(build): correct make build/dev/prod for the nested Go module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Test binary, built with `go test -c`
 *.test
 
+# Compiled backend binary (produced by `make build` / `make prod`)
+/backend/auto-dns-webui
+
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,11 @@
 FRONTEND_DIR=frontend
 BACKEND_DIR=backend
 OUTPUT_BIN=$(BACKEND_DIR)/auto-dns-webui
+# Main package path, relative to BACKEND_DIR (the Go module root).
+MAIN_PKG=./cmd/auto-dns-webui
+# Directory the frontend build is embedded from (see internal/frontend/embed.go's
+# `//go:embed dist/*`).
+EMBED_DIR=$(BACKEND_DIR)/internal/frontend/dist
 
 # --- TASKS ---
 
@@ -32,23 +37,24 @@ help:
 dev:
 	@echo "Running dev mode: Vite + Go (with reverse proxy)"
 	cd $(FRONTEND_DIR) && npm run dev & \
-	go run -tags=dev ./$(BACKEND_DIR)
+	cd $(BACKEND_DIR) && go run -tags=dev $(MAIN_PKG)
 
 build:
 	@echo "Building Go backend in dev mode..."
-	go build -tags=dev -o $(OUTPUT_BIN) ./$(BACKEND_DIR)
+	cd $(BACKEND_DIR) && go build -tags=dev -o auto-dns-webui $(MAIN_PKG)
 
 prod:
 	@echo "Building frontend..."
 	npm install --prefix $(FRONTEND_DIR)
 	npm run build --prefix $(FRONTEND_DIR)
 
-	@echo "Copying frontend build into backend/ for embedding..."
-	rm -rf $(BACKEND_DIR)/dist
-	cp -r $(FRONTEND_DIR)/dist $(BACKEND_DIR)/dist
+	@echo "Copying frontend build into the embed directory..."
+	mkdir -p $(EMBED_DIR)
+	find $(EMBED_DIR) -mindepth 1 ! -name .placeholder -delete 2>/dev/null || true
+	cp -r $(FRONTEND_DIR)/dist/. $(EMBED_DIR)/
 
 	@echo "Building Go backend with embedded frontend..."
-	cd $(BACKEND_DIR) && go build -o auto-dns-webui
+	cd $(BACKEND_DIR) && go build -o auto-dns-webui $(MAIN_PKG)
 
 run-prod: prod
 	@echo "Running production binary..."
@@ -58,6 +64,8 @@ clean:
 	@echo "Cleaning build output..."
 	rm -f $(OUTPUT_BIN)
 	rm -rf $(FRONTEND_DIR)/dist
+	@echo "Clearing embedded frontend build (keeping .placeholder)..."
+	find $(EMBED_DIR) -mindepth 1 ! -name .placeholder -delete 2>/dev/null || true
 
 init:
 	@echo "Creating .devcontainer/.env with default configuration..."

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,10 @@
 
 FRONTEND_DIR=frontend
 BACKEND_DIR=backend
-OUTPUT_BIN=$(BACKEND_DIR)/auto-dns-webui
+# Binary name (built inside BACKEND_DIR) and its path from the repo root. Both
+# derive from BIN_NAME so build/prod and clean/run-prod stay in sync.
+BIN_NAME=auto-dns-webui
+OUTPUT_BIN=$(BACKEND_DIR)/$(BIN_NAME)
 # Main package path, relative to BACKEND_DIR (the Go module root).
 MAIN_PKG=./cmd/auto-dns-webui
 # Directory the frontend build is embedded from (see internal/frontend/embed.go's
@@ -41,7 +44,7 @@ dev:
 
 build:
 	@echo "Building Go backend in dev mode..."
-	cd $(BACKEND_DIR) && go build -tags=dev -o auto-dns-webui $(MAIN_PKG)
+	cd $(BACKEND_DIR) && go build -tags=dev -o $(BIN_NAME) $(MAIN_PKG)
 
 prod:
 	@echo "Building frontend..."
@@ -54,7 +57,7 @@ prod:
 	cp -r $(FRONTEND_DIR)/dist/. $(EMBED_DIR)/
 
 	@echo "Building Go backend with embedded frontend..."
-	cd $(BACKEND_DIR) && go build -o auto-dns-webui $(MAIN_PKG)
+	cd $(BACKEND_DIR) && go build -o $(BIN_NAME) $(MAIN_PKG)
 
 run-prod: prod
 	@echo "Running production binary..."


### PR DESCRIPTION
## Summary

The backend is its own Go module (`backend/go.mod`) with its main package at `backend/cmd/auto-dns-webui`, but the Makefile invoked `go build` / `go run` against `./backend` from the repo root — which has no module — so **`make build`, `make dev`, and `make prod` all failed** with `go: cannot find main module`. `make prod` had a second bug: it copied the frontend build to `backend/dist`, while the `//go:embed dist/*` directive in `internal/frontend/embed.go` reads from `backend/internal/frontend/dist`, so even a successful compile wouldn't have embedded the UI.

Changes:
- Run Go from inside the module: `cd backend && go build/run … ./cmd/auto-dns-webui` (via new `MAIN_PKG` var).
- `prod` copies the frontend build into the real embed dir (`internal/frontend/dist`, via new `EMBED_DIR` var), clearing prior assets while preserving the tracked `.placeholder`.
- `make clean` now also clears the embedded build (keeping `.placeholder`).
- Gitignore the compiled `backend/auto-dns-webui` binary so build/prod leave a clean working tree.

## Linked issues

None — pre-existing build tooling fix surfaced while shipping #9.

## Verification

- `make build`, `make clean`, and `make prod` all succeed.
- The `make prod` binary serves the embedded UI: `GET / → 200` after deleting `frontend/dist` (proving assets are embedded, not served from disk).
- Working tree stays clean after a full `make prod` (embed assets and the binary are gitignored; `.placeholder` unchanged).

## Notes

- Scope was the `prod` bug, but `build`/`dev` shared the identical nested-module root cause, so all three are fixed together.
- `make check`'s backend `golangci-lint` step remains blocked by a pre-existing toolchain mismatch (binary built against go1.25, project targets go1.26.4) — unrelated to this change and not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_019mfrzXhsf2G1TMyfuxzbTu)_